### PR TITLE
fix: resolve Swagger UI configuration - Added OAuthScopes method.

### DIFF
--- a/TTA.WebAPI/Startup.cs
+++ b/TTA.WebAPI/Startup.cs
@@ -170,8 +170,8 @@ public static class Startup
                 // Public Client ID is safe for the browser
                 options.OAuthClientId(app.Configuration["Auth0:ClientId"]);
 
-                // REMOVED: OAuthClientSecret(app.Configuration["Auth0:ClientSecret"]) 
-                // Confidential secrets must never be exposed to the browser UI.
+                // Pre-select checkboxes for the specified scopes in the authorization modal
+                options.OAuthScopes("openid", "profile", "email");
 
                 // PKCE must remain enabled to handle secure code exchange without a secret
                 options.OAuthUsePkce();


### PR DESCRIPTION
- Verified Swagger UI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Swagger UI OAuth configuration to explicitly specify requested authorization scopes (openid, profile, email). The authorization dialog now pre-selects these scopes for improved clarity on permissions being requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->