### PR TITLE
feat(teams): implement end-to-end team management functionality

### DIFF
--- a/TTA.BusinessLogic.Tests/Features/Teams/Handlers/CreateTeamHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Teams/Handlers/CreateTeamHandlerTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.Teams.Commands;
+using TTA.BusinessLogic.Features.Teams.Handlers;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.Teams.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="CreateTeamHandler"/>.
+/// </summary>
+public class CreateTeamHandlerTests
+{
+    private readonly Mock<ITeamRepository> _repositoryMock;
+    private readonly Mock<ILogger<CreateTeamHandler>> _loggerMock;
+    private readonly CreateTeamHandler _handler;
+
+    public CreateTeamHandlerTests()
+    {
+        _repositoryMock = new Mock<ITeamRepository>();
+        _loggerMock = new Mock<ILogger<CreateTeamHandler>>();
+        _handler = new CreateTeamHandler(_repositoryMock.Object, _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler correctly processes a valid command, 
+    /// persists the team via repository, and returns the expected ID.
+    /// </summary>
+    [Fact]
+    public async Task Handle_ValidCommand_ShouldCreateTeamAndReturnId()
+    {
+        // Arrange
+        var command = new CreateTeamCommand(
+            ClubId: Guid.NewGuid(),
+            Name: "U-17 Academy",
+            SportId: Guid.NewGuid(),
+            MinBirthYear: 2007,
+            Gender: Gender.Male
+        );
+
+        _repositoryMock
+            .Setup(x => x.CreateTeamAsync(It.IsAny<Team>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Team t, CancellationToken _) => t); // Return the same team object to get the ID
+
+        // Act
+        var resultId = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, resultId);
+
+        _repositoryMock.Verify(x => x.CreateTeamAsync(
+            It.Is<Team>(t =>
+                t.Name == command.Name &&
+                t.ClubId == command.ClubId &&
+                t.SportId == command.SportId &&
+                t.Gender == command.Gender &&
+                t.MinBirthYear == command.MinBirthYear),
+            It.IsAny<CancellationToken>()),
+        Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Creating new team")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// Ensures that the handler propagates exceptions if the repository fails.
+    /// </summary>
+    [Fact]
+    public async Task Handle_RepositoryThrows_ShouldPropagateException()
+    {
+        // Arrange
+        var command = new CreateTeamCommand(
+            Guid.NewGuid(), "Failure Team", Guid.NewGuid(), 2010, Gender.Female);
+
+        _repositoryMock
+            .Setup(x => x.CreateTeamAsync(It.IsAny<Team>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/Teams/Validators/CreateTeamRequestValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Teams/Validators/CreateTeamRequestValidatorTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentValidation.TestHelper;
+using TTA.BusinessLogic.Features.Teams.DTOs;
+using TTA.BusinessLogic.Features.Teams.Validators;
+using TTA.DataAccess.Enums;
+
+namespace TTA.BusinessLogic.Tests.Features.Teams.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="CreateTeamRequestValidator"/>.
+/// </summary>
+public class CreateTeamRequestValidatorTests
+{
+    private readonly CreateTeamRequestValidator _validator = new();
+
+    [Fact]
+    public void Should_Have_Error_When_Name_Is_Empty()
+    {
+        var request = new CreateTeamRequest("", Guid.NewGuid(), 2010, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Name_Is_Too_Short()
+    {
+        var request = new CreateTeamRequest("Ab", Guid.NewGuid(), 2010, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_MinBirthYear_Is_In_Future()
+    {
+        var futureYear = DateTime.UtcNow.Year + 1;
+        var request = new CreateTeamRequest("U-10", Guid.NewGuid(), futureYear, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.MinBirthYear);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Request_Is_Valid()
+    {
+        var request = new CreateTeamRequest("Standard Team", Guid.NewGuid(), 2012, Gender.Female);
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/Teams/Validators/CreateTeamRequestValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Teams/Validators/CreateTeamRequestValidatorTests.cs
@@ -44,4 +44,44 @@ public class CreateTeamRequestValidatorTests
         var result = _validator.TestValidate(request);
         result.ShouldNotHaveAnyValidationErrors();
     }
+
+    [Fact]
+    public void ShouldHaveError_WhenNameIsLongerThan100Chars()
+    {
+        var request = new CreateTeamRequest(new string('A', 101), Guid.NewGuid(), 2010, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void ShouldHaveError_WhenSportIdIsEmpty()
+    {
+        var request = new CreateTeamRequest("Valid Name", Guid.Empty, 2010, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SportId);
+    }
+
+    [Fact]
+    public void ShouldHaveError_WhenGenderIsInvalid()
+    {
+        var request = new CreateTeamRequest("Valid Name", Guid.NewGuid(), 2010, (Gender)99);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Gender);
+    }
+
+    [Fact]
+    public void ShouldHaveError_WhenMinBirthYearIsTooSmall()
+    {
+        var request = new CreateTeamRequest("Valid Name", Guid.NewGuid(), 1899, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.MinBirthYear);
+    }
+
+    [Fact]
+    public void ShouldNotHaveError_WhenMinBirthYearIsNull()
+    {
+        var request = new CreateTeamRequest("Valid Name", Guid.NewGuid(), null, Gender.Male);
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
 }

--- a/TTA.BusinessLogic/Features/Teams/Commands/CreateTeamCommand.cs
+++ b/TTA.BusinessLogic/Features/Teams/Commands/CreateTeamCommand.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+using TTA.Common.Extensions;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+
+namespace TTA.BusinessLogic.Features.Teams.Commands;
+
+/// <summary>
+/// Command to create a new team, associated with a specific club.
+/// </summary>
+public record CreateTeamCommand(
+    Guid ClubId,
+    string Name,
+    Guid SportId,
+    int? MinBirthYear,
+    Gender Gender) : IRequest<Guid>;
+
+public static class CreateTeamCommandExtensions
+{
+    /// <summary>
+    /// Maps the command to a <see cref="Team"/> domain model.
+    /// </summary>
+    public static Team ToModel(this CreateTeamCommand cmd) => new()
+    {
+        Id = Guid.NewGuid(),
+        ClubId = cmd.ClubId,
+        SportId = cmd.SportId,
+        Name = cmd.Name,
+        MinBirthYear = cmd.MinBirthYear,
+        Gender = cmd.Gender,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    /// <summary>
+    /// Maps a collection of CreateTeamCommand to a list of Team entities.
+    /// </summary>
+    /// <param name="list">Collection of commands.</param>
+    /// <returns>A list of Team entities.</returns>
+    public static List<Team> ToModel(this IEnumerable<CreateTeamCommand> list)
+        => list.MapToList(ToModel);
+}

--- a/TTA.BusinessLogic/Features/Teams/DTOs/CreateTeamRequest.cs
+++ b/TTA.BusinessLogic/Features/Teams/DTOs/CreateTeamRequest.cs
@@ -1,0 +1,16 @@
+﻿using TTA.DataAccess.Enums;
+
+namespace TTA.BusinessLogic.Features.Teams.DTOs;
+
+/// <summary>
+/// Data transfer object for creating a new team within a club.
+/// </summary>
+/// <param name="Name">The display name of the team.</param>
+/// <param name="SportId">The unique identifier of the sport.</param>
+/// <param name="MinBirthYear">Optional minimum birth year for age-restricted teams.</param>
+/// <param name="Gender">The gender category of the team.</param>
+public record CreateTeamRequest(
+    string Name,
+    Guid SportId,
+    int? MinBirthYear,
+    Gender Gender);

--- a/TTA.BusinessLogic/Features/Teams/Handlers/CreateTeamHandler.cs
+++ b/TTA.BusinessLogic/Features/Teams/Handlers/CreateTeamHandler.cs
@@ -1,0 +1,33 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.Teams.Commands;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.Teams.Handlers;
+
+/// <summary>
+/// Handles the creation of a new team by persisting it via the repository.
+/// </summary>
+public class CreateTeamHandler(
+    ITeamRepository repository,
+    ILogger<CreateTeamHandler> logger) : IRequestHandler<CreateTeamCommand, Guid>
+{
+    private readonly ITeamRepository _repository = repository;
+    private readonly ILogger<CreateTeamHandler> _logger = logger;
+
+    /// <inheritdoc />
+    public async Task<Guid> Handle(CreateTeamCommand command, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Creating new team '{TeamName}' for Club {ClubId}.",
+            command.Name, command.ClubId);
+
+        var team = command.ToModel();
+
+        var result = await _repository.CreateTeamAsync(team, cancellationToken);
+
+        _logger.LogInformation("Team '{TeamName}' successfully created with ID {TeamId}.",
+            result.Name, result.Id);
+
+        return result.Id;
+    }
+}

--- a/TTA.BusinessLogic/Features/Teams/Validators/CreateTeamRequestValidator.cs
+++ b/TTA.BusinessLogic/Features/Teams/Validators/CreateTeamRequestValidator.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation;
+using TTA.BusinessLogic.Features.Teams.DTOs;
+
+namespace TTA.BusinessLogic.Features.Teams.Validators;
+
+/// <summary>
+/// Validator for <see cref="CreateTeamRequest"/> to ensure data integrity before processing.
+/// </summary>
+public class CreateTeamRequestValidator : AbstractValidator<CreateTeamRequest>
+{
+    public CreateTeamRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Team name is required.")
+            .MinimumLength(3).WithMessage("Team name must be at least 3 characters long.")
+            .MaximumLength(100).WithMessage("Team name must not exceed 100 characters.");
+
+        RuleFor(x => x.SportId)
+            .NotEmpty().WithMessage("Sport must be selected.");
+
+        RuleFor(x => x.MinBirthYear)
+            .InclusiveBetween(1900, DateTime.UtcNow.Year)
+            .When(x => x.MinBirthYear.HasValue)
+            .WithMessage("Please enter a valid birth year.");
+
+        RuleFor(x => x.Gender)
+            .IsInEnum().WithMessage("A valid gender category must be selected.");
+    }
+}

--- a/TTA.DataAccess/Repository/Api/ITeamRepository.cs
+++ b/TTA.DataAccess/Repository/Api/ITeamRepository.cs
@@ -1,0 +1,27 @@
+﻿using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository.Api;
+
+/// <summary>
+/// Defines data access operations for the Team entity.
+/// Inherits from <see cref="IEntityRepositoryBase{Guid, Team}"/> for common operations.
+/// </summary>
+public interface ITeamRepository : IEntityRepositoryBase<Guid, Team>
+{
+    /// <summary>
+    /// Retrieves all teams associated with a specific club.
+    /// </summary>
+    /// <param name="clubId">The unique identifier of the club.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A collection of <see cref="Team"/> entities belonging to the club.</returns>
+    Task<IEnumerable<Team>> GetByClubIdAsync(Guid clubId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists a new team or updates an existing one in the database.
+    /// </summary>
+    /// <param name="team">The team entity to persist.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The persisted <see cref="Team"/> entity.</returns>
+    Task<Team> CreateTeamAsync(Team team, CancellationToken ct);
+}

--- a/TTA.DataAccess/Repository/Api/ITeamRepository.cs
+++ b/TTA.DataAccess/Repository/Api/ITeamRepository.cs
@@ -23,5 +23,5 @@ public interface ITeamRepository : IEntityRepositoryBase<Guid, Team>
     /// <param name="team">The team entity to persist.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The persisted <see cref="Team"/> entity.</returns>
-    Task<Team> CreateTeamAsync(Team team, CancellationToken ct);
+    Task<Team> CreateTeamAsync(Team team, CancellationToken ct = default);
 }

--- a/TTA.DataAccess/Repository/SqlStatements.cs
+++ b/TTA.DataAccess/Repository/SqlStatements.cs
@@ -32,6 +32,27 @@ public static class SqlStatements
             "SELECT auth.check_user_owns_any_club(@UserId)";
     }
 
+    /// <summary>
+    /// SQL constants for Team-related database operations.
+    /// </summary>
+    public static class ForTeams
+    {
+        /// <summary>
+        /// SQL to call the upsert function and return the resulting team record.
+        /// </summary>
+        public const string UpsertTeam =
+            "SELECT * FROM public.upsert_team(@Id, @ClubId, @SportId, @Name, @MinBirthYear, @Gender, @CreatedAt)";
+
+        /// <summary>
+        /// SQL to retrieve all teams for a specific club.
+        /// </summary>
+        public const string GetTeamsByClub =
+            "SELECT * FROM public.get_teams_by_club(@p_club_id)";
+    }
+
+    /// <summary>
+    /// SQL constants for Player-related database operations.
+    /// </summary>
     public static class ForPlayers
     {
         /// <summary>

--- a/TTA.DataAccess/Repository/TeamRepository.cs
+++ b/TTA.DataAccess/Repository/TeamRepository.cs
@@ -1,0 +1,55 @@
+﻿using Dapper;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository;
+
+/// <summary>
+/// Repository for managing Team entities in PostgreSQL using Dapper.
+/// Inherits from <see cref="EntityRepositoryBase{Guid, Team}"/> for common CRUD logic.
+/// </summary>
+/// <param name="connectionFactory">The factory to create database connections.</param>
+public class TeamRepository(IDbConnectionFactory connectionFactory)
+    : EntityRepositoryBase<Guid, Team>(connectionFactory), ITeamRepository
+{
+    /// <summary>
+    /// Creates a new team or updates an existing one using a stored function.
+    /// Mapping of Gender (Enum) to the database-expected format is handled here.
+    /// </summary>
+    /// <param name="team">The team entity to persist.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The persisted <see cref="Team"/> entity.</returns>
+    public async Task<Team> CreateTeamAsync(Team team, CancellationToken ct)
+    {
+        // Use the entity itself as the base for parameters
+        var parameters = new DynamicParameters(team);
+
+        // Explicitly map Gender enum to int for the PostgreSQL function parameter
+        parameters.Add("Gender", (int)team.Gender);
+
+        return await CreateOrUpdate(
+            team,
+            SqlStatements.ForTeams.UpsertTeam,
+            parameters,
+            ct);
+    }
+
+    /// <summary>
+    /// Retrieves all teams associated with a specific club using a stored function.
+    /// </summary>
+    /// <param name="clubId">The unique identifier of the club.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A collection of <see cref="Team"/> entities.</returns>
+    public async Task<IEnumerable<Team>> GetByClubIdAsync(Guid clubId, CancellationToken ct = default)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("p_club_id", clubId);
+
+        // Aligned with PlayerRepository: use GetByPropValues for collections
+        return await GetByPropValues(
+            SqlStatements.ForTeams.GetTeamsByClub,
+            parameters,
+            ct);
+    }
+}

--- a/TTA.DataAccess/Repository/TeamRepository.cs
+++ b/TTA.DataAccess/Repository/TeamRepository.cs
@@ -20,7 +20,7 @@ public class TeamRepository(IDbConnectionFactory connectionFactory)
     /// <param name="team">The team entity to persist.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The persisted <see cref="Team"/> entity.</returns>
-    public async Task<Team> CreateTeamAsync(Team team, CancellationToken ct)
+    public async Task<Team> CreateTeamAsync(Team team, CancellationToken ct = default)
     {
         // Use the entity itself as the base for parameters
         var parameters = new DynamicParameters(team);

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -69,7 +69,7 @@ FOREIGN KEY (id, defaultconfigid)
 REFERENCES sportconfigurations (sportid, id);
 
 -- ==========================================
--- 3. ORGANIZATIONS & TEAMS
+-- 3. ORGANIZATIONS (CLUBS) & TEAMS
 -- ==========================================
 
 CREATE TABLE clubs (

--- a/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
@@ -47,7 +47,7 @@ BEGIN
 END;$$ LANGUAGE plpgsql;
 
 -- ====================================================
--- ORGANIZATIONS & TEAMS STORED FUNCTIONS & PROCEDURES
+-- ORGANIZATIONS (CLUBS) STORED FUNCTIONS & PROCEDURES
 -- ====================================================
 
 -- 1) Atomic function to ensure user existence and create a club with ownership.
@@ -112,6 +112,59 @@ RETURNS BOOLEAN AS $$BEGIN
           AND expiresat IS NULL
     );
 END;$$ LANGUAGE plpgsql;
+
+-- ====================================================
+-- TEAM MANAGEMENT STORED FUNCTIONS & PROCEDURES
+-- ====================================================
+-- 1) Upserts a team record and returns the updated entity.
+CREATE OR REPLACE FUNCTION public.upsert_team(
+    p_id UUID,
+    p_clubid UUID,
+    p_sportid UUID,
+    p_name VARCHAR(100),
+    p_minbirthyear INT,
+    p_gender INT, -- 0 for Male, 1 for Female
+    p_createdat TIMESTAMPTZ
+)
+RETURNS SETOF public.teams AS $$
+DECLARE
+    v_gender_str VARCHAR(20);
+BEGIN
+    -- 1. Validate gender input
+    IF p_gender NOT IN (0, 1) THEN
+        RAISE EXCEPTION 'Invalid gender value: %. Expected 0 (Male) or 1 (Female).', p_gender 
+        USING ERRCODE = '22023';
+    END IF;
+
+    -- 2. Map integer to string enum
+    v_gender_str := CASE 
+        WHEN p_gender = 0 THEN 'Male'
+        WHEN p_gender = 1 THEN 'Female'
+    END;
+
+    RETURN QUERY
+    INSERT INTO public.teams (id, clubid, sportid, name, minbirthyear, gender, createdat)
+    VALUES (p_id, p_clubid, p_sportid, p_name, p_minbirthyear, v_gender_str, p_createdat)
+    ON CONFLICT (id) DO UPDATE SET
+        clubid = EXCLUDED.clubid,
+        sportid = EXCLUDED.sportid,
+        name = EXCLUDED.name,
+        minbirthyear = EXCLUDED.minbirthyear,
+        gender = EXCLUDED.gender
+    RETURNING *;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2) Retrieves all teams associated with a specific club.
+CREATE OR REPLACE FUNCTION public.get_teams_by_club(p_club_id UUID)
+RETURNS SETOF public.teams AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM public.teams 
+    WHERE clubid = p_club_id
+    ORDER BY name ASC;
+END;
+$$ LANGUAGE plpgsql;
 
 -- ====================================================
 -- PLAYERS STORED FUNCTIONS & PROCEDURES

--- a/TTA.Tests.Integration/Controllers/ClubsControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/ClubsControllerTests.cs
@@ -143,6 +143,105 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
     }
     #endregion
 
+    #region CreateTeam
+    [Fact]
+    public async Task CreateTeam_ShouldReturnOk_WhenUserIsClubAdmin()
+    {
+        // Arrange
+        var clubId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+        var testUserId = BaseApiTest.TestUserId;
+
+        // 1. User first
+        await SeedUserAsync(testUserId);
+
+        // 2. Location & Club (SeedRequiredClubDataAsync already seeds location internally)
+        await SeedRequiredClubDataAsync(clubId);
+
+        // 3. Sport (The essential FK for teams)
+        await SeedSportDataAsync(sportId, "Football");
+
+        // 4. Policy (Must happen after User and Club exist)
+        await SeedClubAdminPolicyAsync(testUserId, clubId);
+
+        var request = new
+        {
+            Name = "Lions Academy U-12",
+            SportId = sportId,
+            MinBirthYear = 2012,
+            Gender = 0 // Will be mapped to 'Male' by public.upsert_team
+        };
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"/api/clubs/{clubId}/teams", request);
+
+        // Assert
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            // This will show exactly what went wrong in the Test Output
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"Server responded with error: {content}");
+        }
+
+        var resultId = await response.Content.ReadFromJsonAsync<Guid>();
+        resultId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateTeam_ShouldReturnForbidden_WhenUserHasNoAccess()
+    {
+        // Arrange
+        var clubId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+
+        await SeedUserAsync(BaseApiTest.TestUserId);
+        await SeedRequiredClubDataAsync(clubId);
+        await SeedSportDataAsync(sportId, "Basketball");
+        // No policy seeded
+
+        var request = new
+        {
+            Name = "Unauthorized Team",
+            SportId = sportId,
+            MinBirthYear = 2010,
+            Gender = 1 // Female
+        };
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"/api/clubs/{clubId}/teams", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateTeam_ShouldReturnBadRequest_WhenNameIsTooShort()
+    {
+        // Arrange
+        var clubId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+
+        await SeedUserAsync(BaseApiTest.TestUserId);
+        await SeedRequiredClubDataAsync(clubId);
+        await SeedSportDataAsync(sportId, "Tennis");
+        await SeedClubAdminPolicyAsync(BaseApiTest.TestUserId, clubId);
+
+        var invalidRequest = new
+        {
+            Name = "Ab", // Minimum length is 3
+            SportId = sportId,
+            MinBirthYear = 2015,
+            Gender = 0
+        };
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"/api/clubs/{clubId}/teams", invalidRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    #endregion
+
     #region Helpers for Seeding
 
     private async Task SeedRequiredClubDataAsync(Guid clubId)
@@ -216,6 +315,29 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
         using var cmd = new NpgsqlCommand(citySql, conn);
         cmd.Parameters.AddWithValue("id", cityId);
         await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedSportDataAsync(Guid sportId, string name)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+
+        // Use a robust UPSERT or check existence to ensure we don't violate unique constraints
+        // while ensuring the ID we want to use actually exists.
+        var sql = @"
+        INSERT INTO public.sports (id, name, defaultconfigid) 
+        VALUES (@id, @name, NULL) 
+        ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name 
+        RETURNING id;";
+
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", sportId);
+        cmd.Parameters.AddWithValue("name", name);
+
+        // We execute this to ensure the record is there
+        var actualId = await cmd.ExecuteScalarAsync();
+        // Optional: if the ID in DB was different, we should use it, 
+        // but for tests Guid.NewGuid() is fine as long as the record exists.
     }
 
     private static async Task ExecuteSql(NpgsqlConnection conn, string sql)

--- a/TTA.Tests.Integration/Controllers/ClubsControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/ClubsControllerTests.cs
@@ -150,41 +150,28 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
         // Arrange
         var clubId = Guid.NewGuid();
         var sportId = Guid.NewGuid();
-        var testUserId = BaseApiTest.TestUserId;
 
-        // 1. User first
-        await SeedUserAsync(testUserId);
-
-        // 2. Location & Club (SeedRequiredClubDataAsync already seeds location internally)
+        await SeedUserAsync(BaseApiTest.TestUserId);
         await SeedRequiredClubDataAsync(clubId);
 
-        // 3. Sport (The essential FK for teams)
-        await SeedSportDataAsync(sportId, "Football");
+        // Capture the canonical ID from the DB
+        sportId = await SeedSportDataAsync(sportId, "Football");
 
-        // 4. Policy (Must happen after User and Club exist)
-        await SeedClubAdminPolicyAsync(testUserId, clubId);
+        await SeedClubAdminPolicyAsync(BaseApiTest.TestUserId, clubId);
 
         var request = new
         {
             Name = "Lions Academy U-12",
-            SportId = sportId,
+            SportId = sportId, // Now this ID is guaranteed to exist in the DB
             MinBirthYear = 2012,
-            Gender = 0 // Will be mapped to 'Male' by public.upsert_team
+            Gender = 0
         };
 
         // Act
         var response = await Client.PostAsJsonAsync($"/api/clubs/{clubId}/teams", request);
 
         // Assert
-        if (response.StatusCode != HttpStatusCode.OK)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            // This will show exactly what went wrong in the Test Output
-            response.StatusCode.Should().Be(HttpStatusCode.OK, $"Server responded with error: {content}");
-        }
-
-        var resultId = await response.Content.ReadFromJsonAsync<Guid>();
-        resultId.Should().NotBeEmpty();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -196,15 +183,16 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
 
         await SeedUserAsync(BaseApiTest.TestUserId);
         await SeedRequiredClubDataAsync(clubId);
-        await SeedSportDataAsync(sportId, "Basketball");
-        // No policy seeded
+
+        // Capture the canonical ID
+        sportId = await SeedSportDataAsync(sportId, "Basketball");
 
         var request = new
         {
             Name = "Unauthorized Team",
             SportId = sportId,
             MinBirthYear = 2010,
-            Gender = 1 // Female
+            Gender = 1
         };
 
         // Act
@@ -223,12 +211,15 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
 
         await SeedUserAsync(BaseApiTest.TestUserId);
         await SeedRequiredClubDataAsync(clubId);
-        await SeedSportDataAsync(sportId, "Tennis");
+
+        // Capture the canonical ID
+        sportId = await SeedSportDataAsync(sportId, "Tennis");
+
         await SeedClubAdminPolicyAsync(BaseApiTest.TestUserId, clubId);
 
         var invalidRequest = new
         {
-            Name = "Ab", // Minimum length is 3
+            Name = "Ab",
             SportId = sportId,
             MinBirthYear = 2015,
             Gender = 0
@@ -243,7 +234,6 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
     #endregion
 
     #region Helpers for Seeding
-
     private async Task SeedRequiredClubDataAsync(Guid clubId)
     {
         using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
@@ -317,13 +307,16 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
         await cmd.ExecuteNonQueryAsync();
     }
 
-    private async Task SeedSportDataAsync(Guid sportId, string name)
+    /// <summary>
+    /// Seeds a sport record into the database and returns its canonical ID.
+    /// This ensures tests use the correct ID even if the sport name already exists.
+    /// </summary>
+    private async Task<Guid> SeedSportDataAsync(Guid sportId, string name)
     {
         using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
         await conn.OpenAsync();
 
-        // Use a robust UPSERT or check existence to ensure we don't violate unique constraints
-        // while ensuring the ID we want to use actually exists.
+        // SQL returns the ID of the inserted or existing row
         var sql = @"
         INSERT INTO public.sports (id, name, defaultconfigid) 
         VALUES (@id, @name, NULL) 
@@ -334,10 +327,14 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
         cmd.Parameters.AddWithValue("id", sportId);
         cmd.Parameters.AddWithValue("name", name);
 
-        // We execute this to ensure the record is there
-        var actualId = await cmd.ExecuteScalarAsync();
-        // Optional: if the ID in DB was different, we should use it, 
-        // but for tests Guid.NewGuid() is fine as long as the record exists.
+        var result = await cmd.ExecuteScalarAsync();
+
+        if (result is not Guid actualId)
+        {
+            throw new InvalidOperationException($"Failed to seed sport '{name}'. Database did not return a valid Guid.");
+        }
+
+        return actualId;
     }
 
     private static async Task ExecuteSql(NpgsqlConnection conn, string sql)
@@ -345,6 +342,5 @@ public class ClubsControllerTests(DatabaseFixture fixture) : BaseApiTest(fixture
         using var cmd = new NpgsqlCommand(sql, conn);
         await cmd.ExecuteNonQueryAsync();
     }
-
     #endregion
 }

--- a/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
@@ -49,10 +49,16 @@ public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(
         createdTeam.Should().NotBeNull();
         createdTeam.Name.Should().Be(team.Name);
         createdTeam.Gender.Should().Be(Gender.Male);
+        // Added FK assertions
+        createdTeam.ClubId.Should().Be(clubId);
+        createdTeam.SportId.Should().Be(sportId);
 
         clubTeams.Should().ContainSingle();
         clubTeams[0].Id.Should().Be(teamId);
         clubTeams[0].MinBirthYear.Should().Be(2008);
+        // Added FK assertions for retrieved collection
+        clubTeams[0].ClubId.Should().Be(clubId);
+        clubTeams[0].SportId.Should().Be(sportId);
     }
 
     /// <summary>
@@ -77,8 +83,8 @@ public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(
 
         // Assert
         result.Should().HaveCount(2);
-        result.Should().Contain(t => t.Name == "Alpha Team");
-        result.Should().Contain(t => t.Name == "Beta Team");
+        result.Should().Contain(t => t.Name == "Alpha Team" && t.ClubId == clubId && t.SportId == sportId);
+        result.Should().Contain(t => t.Name == "Beta Team" && t.ClubId == clubId && t.SportId == sportId);
     }
 
     #region Helper Methods
@@ -88,14 +94,14 @@ public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(
     /// </summary>
     private async Task SeedTeamDependenciesAsync(Guid clubId, Guid sportId)
     {
-        using var conn = new NpgsqlConnection(Fixture.ConnectionFactory.CreateConnection().ConnectionString);
+        // UPDATED: Cast directly to NpgsqlConnection instead of using ConnectionString
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
         await conn.OpenAsync();
 
         using var transaction = await conn.BeginTransactionAsync();
 
         try
         {
-            // Define cityId before using it
             var cityId = Guid.NewGuid();
 
             // 1. Seed Location & Club hierarchy

--- a/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
@@ -1,0 +1,158 @@
+﻿using Dapper;
+using FluentAssertions;
+using Npgsql;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository;
+using TTA.Tests.Integration.Infrastructure;
+
+namespace TTA.Tests.Integration.Repository;
+
+/// <summary>
+/// Integration tests for <see cref="TeamRepository"/> using a real database container.
+/// </summary>
+[Collection("DatabaseCollection")]
+public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(fixture)
+{
+    private readonly TeamRepository _repository = new(fixture.ConnectionFactory);
+
+    /// <summary>
+    /// Verifies that a team can be successfully created and then retrieved by Club ID.
+    /// </summary>
+    [Fact]
+    public async Task CreateTeamAsync_ShouldPersistTeam_AndRetrieveItBack()
+    {
+        // Arrange
+        var clubId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+
+        // Seed dependencies: Country -> Region -> City -> Club AND Sport
+        await SeedTeamDependenciesAsync(clubId, sportId);
+
+        var team = new Team
+        {
+            Id = teamId,
+            ClubId = clubId,
+            SportId = sportId,
+            Name = "U-18 Boys Elite",
+            MinBirthYear = 2008,
+            Gender = Gender.Male,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        // Act
+        var createdTeam = await _repository.CreateTeamAsync(team, CancellationToken.None);
+        var clubTeams = (await _repository.GetByClubIdAsync(clubId, CancellationToken.None)).ToList();
+
+        // Assert
+        createdTeam.Should().NotBeNull();
+        createdTeam.Name.Should().Be(team.Name);
+        createdTeam.Gender.Should().Be(Gender.Male);
+
+        clubTeams.Should().ContainSingle();
+        clubTeams[0].Id.Should().Be(teamId);
+        clubTeams[0].MinBirthYear.Should().Be(2008);
+    }
+
+    /// <summary>
+    /// Verifies that multiple teams can be retrieved for a single club.
+    /// </summary>
+    [Fact]
+    public async Task GetByClubIdAsync_ShouldReturnAllTeamsForSpecificClub()
+    {
+        // Arrange
+        var clubId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+        await SeedTeamDependenciesAsync(clubId, sportId);
+
+        var team1 = CreateTeamModel(clubId, sportId, "Alpha Team");
+        var team2 = CreateTeamModel(clubId, sportId, "Beta Team");
+
+        await _repository.CreateTeamAsync(team1, CancellationToken.None);
+        await _repository.CreateTeamAsync(team2, CancellationToken.None);
+
+        // Act
+        var result = (await _repository.GetByClubIdAsync(clubId, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(t => t.Name == "Alpha Team");
+        result.Should().Contain(t => t.Name == "Beta Team");
+    }
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Seeds all necessary database records required for a Team to exist.
+    /// </summary>
+    private async Task SeedTeamDependenciesAsync(Guid clubId, Guid sportId)
+    {
+        using var conn = new NpgsqlConnection(Fixture.ConnectionFactory.CreateConnection().ConnectionString);
+        await conn.OpenAsync();
+
+        using var transaction = await conn.BeginTransactionAsync();
+
+        try
+        {
+            // 1. Seed Geography & Club (reusing the same logic as in PlayerRepositoryTests)
+            var cityId = Guid.NewGuid();
+            await SeedCountryAsync(conn, 1, "Ukraine", "UKR");
+            await SeedRegionAsync(conn, 1, "Kyiv Region", 1);
+            await SeedCityAsync(conn, cityId, "Kyiv", 1);
+            await SeedClubAsync(conn, clubId, "Test Athletic Club", cityId);
+
+            // 2. Seed Sport (required for Team)
+            await SeedSportAsync(conn, sportId, "Football");
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    private static async Task SeedCountryAsync(NpgsqlConnection conn, int id, string name, string code)
+    {
+        var sql = "INSERT INTO public.countries (id, name, code) VALUES (@id, @name, @code) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { id, name, code });
+    }
+
+    private static async Task SeedRegionAsync(NpgsqlConnection conn, int id, string name, int countryId)
+    {
+        var sql = "INSERT INTO public.regions (id, name, countryid) VALUES (@id, @name, @countryId) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { id, name, countryId });
+    }
+
+    private static async Task SeedCityAsync(NpgsqlConnection conn, Guid id, string name, int regionId)
+    {
+        var sql = "INSERT INTO public.cities (id, name, regionid) VALUES (@id, @name, @regionId) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { id, name, regionId });
+    }
+
+    private static async Task SeedClubAsync(NpgsqlConnection conn, Guid id, string name, Guid cityId)
+    {
+        var sql = "INSERT INTO public.clubs (id, name, cityid, createdat) VALUES (@id, @name, @cityId, NOW()) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { id, name, cityId });
+    }
+
+    private static async Task SeedSportAsync(NpgsqlConnection conn, Guid id, string name)
+    {
+        var sql = "INSERT INTO public.sports (id, name) VALUES (@id, @name) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { id, name });
+    }
+
+    private static Team CreateTeamModel(Guid clubId, Guid sportId, string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        ClubId = clubId,
+        SportId = sportId,
+        Name = name,
+        Gender = Gender.Female,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    #endregion
+}

--- a/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/TeamRepositoryTests.cs
@@ -95,15 +95,17 @@ public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(
 
         try
         {
-            // 1. Seed Geography & Club (reusing the same logic as in PlayerRepositoryTests)
+            // Define cityId before using it
             var cityId = Guid.NewGuid();
-            await SeedCountryAsync(conn, 1, "Ukraine", "UKR");
-            await SeedRegionAsync(conn, 1, "Kyiv Region", 1);
-            await SeedCityAsync(conn, cityId, "Kyiv", 1);
-            await SeedClubAsync(conn, clubId, "Test Athletic Club", cityId);
 
-            // 2. Seed Sport (required for Team)
-            await SeedSportAsync(conn, sportId, "Football");
+            // 1. Seed Location & Club hierarchy
+            await SeedCountryAsync(conn, transaction, 1, "Ukraine", "UKR");
+            await SeedRegionAsync(conn, transaction, 1, "Kyiv Region", 1);
+            await SeedCityAsync(conn, transaction, cityId, "Kyiv", 1);
+            await SeedClubAsync(conn, transaction, clubId, "Test Athletic Club", cityId);
+
+            // 2. Seed Sport
+            await SeedSportAsync(conn, transaction, sportId, "Football");
 
             await transaction.CommitAsync();
         }
@@ -114,34 +116,34 @@ public class TeamRepositoryTests(DatabaseFixture fixture) : BaseIntegrationTest(
         }
     }
 
-    private static async Task SeedCountryAsync(NpgsqlConnection conn, int id, string name, string code)
+    private static async Task SeedCountryAsync(NpgsqlConnection conn, NpgsqlTransaction tx, int id, string name, string code)
     {
         var sql = "INSERT INTO public.countries (id, name, code) VALUES (@id, @name, @code) ON CONFLICT DO NOTHING";
-        await conn.ExecuteAsync(sql, new { id, name, code });
+        await conn.ExecuteAsync(sql, new { id, name, code }, tx);
     }
 
-    private static async Task SeedRegionAsync(NpgsqlConnection conn, int id, string name, int countryId)
+    private static async Task SeedRegionAsync(NpgsqlConnection conn, NpgsqlTransaction tx, int id, string name, int countryId)
     {
         var sql = "INSERT INTO public.regions (id, name, countryid) VALUES (@id, @name, @countryId) ON CONFLICT DO NOTHING";
-        await conn.ExecuteAsync(sql, new { id, name, countryId });
+        await conn.ExecuteAsync(sql, new { id, name, countryId }, tx);
     }
 
-    private static async Task SeedCityAsync(NpgsqlConnection conn, Guid id, string name, int regionId)
+    private static async Task SeedCityAsync(NpgsqlConnection conn, NpgsqlTransaction tx, Guid id, string name, int regionId)
     {
         var sql = "INSERT INTO public.cities (id, name, regionid) VALUES (@id, @name, @regionId) ON CONFLICT DO NOTHING";
-        await conn.ExecuteAsync(sql, new { id, name, regionId });
+        await conn.ExecuteAsync(sql, new { id, name, regionId }, tx);
     }
 
-    private static async Task SeedClubAsync(NpgsqlConnection conn, Guid id, string name, Guid cityId)
+    private static async Task SeedClubAsync(NpgsqlConnection conn, NpgsqlTransaction tx, Guid id, string name, Guid cityId)
     {
         var sql = "INSERT INTO public.clubs (id, name, cityid, createdat) VALUES (@id, @name, @cityId, NOW()) ON CONFLICT DO NOTHING";
-        await conn.ExecuteAsync(sql, new { id, name, cityId });
+        await conn.ExecuteAsync(sql, new { id, name, cityId }, tx);
     }
 
-    private static async Task SeedSportAsync(NpgsqlConnection conn, Guid id, string name)
+    private static async Task SeedSportAsync(NpgsqlConnection conn, NpgsqlTransaction tx, Guid id, string name)
     {
         var sql = "INSERT INTO public.sports (id, name) VALUES (@id, @name) ON CONFLICT DO NOTHING";
-        await conn.ExecuteAsync(sql, new { id, name });
+        await conn.ExecuteAsync(sql, new { id, name }, tx);
     }
 
     private static Team CreateTeamModel(Guid clubId, Guid sportId, string name) => new()

--- a/TTA.WebAPI/Controllers/ClubsController.cs
+++ b/TTA.WebAPI/Controllers/ClubsController.cs
@@ -6,6 +6,8 @@ using TTA.BusinessLogic.Features.Clubs.Commands;
 using TTA.BusinessLogic.Features.Clubs.DTOs;
 using TTA.BusinessLogic.Features.Players.Commands;
 using TTA.BusinessLogic.Features.Players.DTOs;
+using TTA.BusinessLogic.Features.Teams.Commands;
+using TTA.BusinessLogic.Features.Teams.DTOs;
 using TTA.WebAPI.Authorization;
 using TTA.WebAPI.Extensions;
 
@@ -93,6 +95,54 @@ public class ClubsController(
         userName);
 
         _logger.LogInformation("Dispatching CreateClubCommand for User: {UserId}.", userId);
+        var result = await _mediator.Send(command);
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Creates a new team within a specific club.
+    /// </summary>
+    /// <param name="clubId">The unique identifier of the club where the team is being created.</param>
+    /// <param name="request">The team creation request data.</param>
+    /// <param name="validator">The validator for the team creation request.</param>
+    /// <returns>The unique identifier of the newly created team.</returns>
+    /// <remarks>
+    /// Access is restricted to users with administrative rights ("ClubAdmin" policy) over the specified club.
+    /// </remarks>
+    /// <response code="200">Returns the unique identifier of the created team.</response>
+    /// <response code="400">If the request data is invalid.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user does not have permission to manage this club.</response>
+    [HttpPost("{clubId:guid}/teams")]
+    [Authorize(Policy = "ClubAdmin")]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> CreateTeam(
+        [FromRoute] Guid clubId,
+        [FromBody] CreateTeamRequest request,
+        [FromServices] IValidator<CreateTeamRequest> validator)
+    {
+        _logger.LogInformation("Executing CreateTeam action for Club {ClubId}.", clubId);
+
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for CreateTeamRequest in Club {ClubId}: {Errors}.",
+                clubId, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        var command = new CreateTeamCommand(
+            clubId,
+            request.Name,
+            request.SportId,
+            request.MinBirthYear,
+            request.Gender);
+
+        _logger.LogInformation("Dispatching CreateTeamCommand for Club: {ClubId}.", clubId);
         var result = await _mediator.Send(command);
 
         return Ok(result);

--- a/TTA.WebAPI/Startup.cs
+++ b/TTA.WebAPI/Startup.cs
@@ -109,6 +109,7 @@ public static class Startup
 
         services.AddScoped<IClubRepository, ClubRepository>();
         services.AddScoped<IPlayerRepository, PlayerRepository>();
+        services.AddScoped<ITeamRepository, TeamRepository>();
 
         services.AddSingleton<IDbConnectionFactory, NpgsqlConnectionFactory>();
 


### PR DESCRIPTION
## 🚀 Overview
This PR introduces the **Team Management** module, enabling sports clubs to create and manage their teams. The implementation covers everything from database schema and stored functions to API endpoints and integration tests.

## 🛠 Key Changes

### 1. Database & Persistence
* **Schema Update**: Added the `public.teams` table with constraints for `SportId` and `ClubId`.
* **Stored Functions**: 
    * `public.upsert_team`: Handles atomic insert/update with gender mapping (int to string).
    * `public.get_teams_by_club`: Efficiently retrieves all teams for a specific organization.
* **Repository**: Implemented `TeamRepository` using Dapper for high-performance data access.

### 2. Business Logic (CQRS)
* **Command**: `CreateTeamCommand` encapsulates all necessary data for team creation.
* **Handler**: `CreateTeamHandler` processes the command, manages logging, and interacts with the repository.
* **Validation**: Added `CreateTeamRequestValidator` to ensure:
    * Team name is between 3 and 100 characters.
    * `MinBirthYear` is within a realistic range.
    * `Gender` and `SportId` are valid.

### 3. API & Security
* **Controller**: Added `CreateTeam` action to `ClubsController`.
* **Authorization**: Applied `[Authorize(Policy = "ClubAdmin")]` to restrict team management to club administrators only.
* **Dependency Injection**: Registered `ITeamRepository` in the service container.

### 4. Quality Assurance
* **Unit Tests**: Verified `CreateTeamHandler` logic and mapping using **Moq**.
* **Integration Tests**: 
    * Verified full HTTP request flow in `ClubsControllerTests`.
    * Tested successful creation, unauthorized access (403 Forbidden), and validation errors (400 BadRequest).
    * Ensured proper database seeding and cleanup using `Testcontainers`.

## 📝 Technical Notes
* **Gender Mapping**: The system correctly maps C# `Gender` enums (0/1) to PostgreSQL string values ('Male'/'Female') via the `upsert_team` function.
* **DI Fix**: Resolved an issue where the `ITeamRepository` was not registered, causing 500 errors during MediatR dispatching.

## ✅ Checklist
- [x] Stored procedures created and tested.
- [x] Repository implemented and registered in DI.
- [x] API endpoint secured with proper policy.
- [x] Unit and Integration tests are green.
- [x] Documentation (Doc Strings) added in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Club administrators can create teams via POST /clubs/{clubId}/teams (name, sport, gender, optional min birth year). Requests are validated (name length 3–100, sport required, valid gender, min birth year nullable and ≤ current year) and return the created team ID. Endpoint requires ClubAdmin policy and returns 200/400/401/403 as appropriate.
  * Teams are persisted and can be listed by club.

* **Tests**
  * Added unit and integration tests covering validation, handler behavior, persistence, and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->