### PR TITLE
feat: enable global string enum serialization in API

### DIFF
--- a/TTA.BusinessLogic/Features/Teams/Commands/AddTeamMemberCommand.cs
+++ b/TTA.BusinessLogic/Features/Teams/Commands/AddTeamMemberCommand.cs
@@ -1,5 +1,4 @@
 ﻿using MediatR;
-using System.ComponentModel.DataAnnotations;
 using TTA.DataAccess.Enums;
 using TTA.DataAccess.Models;
 
@@ -11,7 +10,6 @@ namespace TTA.BusinessLogic.Features.Teams.Commands;
 public record AddTeamMemberCommand(
     Guid TeamId,
     string UserEmail,
-    [EnumDataType(typeof(TeamRole))]
     TeamRole RoleInTeam,
     bool IsPrimary) : IRequest<Guid>;
 

--- a/TTA.DataAccess/SQLScripts/02-Infrastructure-and-Seed.sql
+++ b/TTA.DataAccess/SQLScripts/02-Infrastructure-and-Seed.sql
@@ -136,7 +136,7 @@ END $$;
 DO $$ 
 DECLARE 
     v_user_id VARCHAR := 'auth0|69cf7ec5eff8f1358a0b9ae0'; 
-    v_team_id UUID := '22222222-2222-2222-2222-222222222201'; 
+    v_team_id UUID := '22222222-2222-2222-2222-222222222215'; 
     v_new_club_id UUID := '11111111-1111-1111-1111-111111111110';
 BEGIN
     -- 1. Ensure user exists
@@ -146,7 +146,7 @@ BEGIN
 
     -- 2. Existing Team Membership (for old tests)
     INSERT INTO public.teammemberships (id, userid, teamid, roleinteam, joinedat, isprimary)
-    SELECT '99999999-9999-9999-9999-999999999901', v_user_id, v_team_id, 0, NOW(), true -- CHANGED: HeadCoach -> 0
+    SELECT '99999999-9999-9999-9999-999999999901', v_user_id, v_team_id, 0, NOW(), true -- roleinteam: HeadCoach -> 0
     WHERE NOT EXISTS (
         SELECT 1 FROM public.teammemberships 
         WHERE userid = v_user_id AND teamid = v_team_id
@@ -154,10 +154,10 @@ BEGIN
 
     -- 3. Policy for the OLD Team
     INSERT INTO auth.accesspolicies (id, userid, role, targettype, targetid, createdat)
-    SELECT '99999999-9999-9999-9999-999999999902', v_user_id, 1, 2, v_team_id, NOW() -- CHANGED: Editor -> 1, Team -> 2
+    SELECT '99999999-9999-9999-9999-999999999902', v_user_id, 0, 2, v_team_id, NOW() -- role: FullControl -> 0, targettype: Team -> 2
     WHERE NOT EXISTS (
         SELECT 1 FROM auth.accesspolicies 
-        WHERE userid = v_user_id AND targettype = 2 AND targetid = v_team_id -- CHANGED: Team -> 2
+        WHERE userid = v_user_id AND targettype = 2 AND targetid = v_team_id -- targettype: Team -> 2
     );
 
     -- 4. NEW: Policy for "My super club" (FullControl so you can add players)
@@ -165,14 +165,14 @@ BEGIN
     SELECT 
         '99999999-9999-9999-9999-999999999910', 
         v_user_id, 
-        0, -- CHANGED: FullControl -> 0
-        1, -- CHANGED: Club -> 1
+        0, -- role: FullControl -> 0
+        1, -- targettype: Club -> 1
         v_new_club_id, 
         NOW()
     WHERE NOT EXISTS (
         SELECT 1 FROM auth.accesspolicies 
         WHERE userid = v_user_id 
-          AND targettype = 1 -- CHANGED: Club -> 1
+          AND targettype = 1 -- targettype: Club -> 1
           AND targetid = v_new_club_id
     );
 

--- a/TTA.WebAPI/Startup.cs
+++ b/TTA.WebAPI/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi.Models;
 using Serilog;
 using Serilog.Exceptions;
+using System.Text.Json.Serialization;
 using TTA.BusinessLogic;
 using TTA.BusinessLogic.Services;
 using TTA.BusinessLogic.Services.Api;
@@ -120,7 +121,15 @@ public static class Startup
 
         services.AddSingleton<IDbConnectionFactory, NpgsqlConnectionFactory>();
 
-        services.AddControllers();
+        // Add services to the container.
+        services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            // Global configuration to serialize/deserialize Enums as strings (e.g., "ClubDirector") 
+            // instead of numeric values (e.g., 0). This improves API readability and Swagger UI integration.
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
+
         services.AddExceptionHandler<GlobalExceptionHandler>();
         services.AddProblemDetails();
         services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## 🎯 Overview
This PR introduces global support for **String Enum Serialization** across the entire API. This change simplifies integration for frontend clients and enhances the developer experience when using Swagger UI.

---

## 🛠 Changes Breakdown

### 🟦 Core Configuration
* **`Program.cs`**: Added `JsonStringEnumConverter` to the global `JsonSerializerOptions`.
* **Serialization Logic**: The API now accepts and returns string representations of enums (e.g., `"ClubDirector"`) instead of their underlying integer values (e.g., `3`).

---

## 📊 Impact Summary

| Feature | Before | After |
| :--- | :---: | :---: |
| **API Requests** | Required `INT` (0, 1, 2) | Accepts `STRING` ("ClubDirector") |
| **Swagger UI** | Textbox for numbers | Dropdown list with labels |
| **Readability** | Obscure numeric codes | Human-readable role names |

---

## 🧪 Verified Scenarios
> [!TIP]
> This change affects all endpoints using Enums, including `AddTeamMemberRequest`.

- [x] **Swagger Integration**: Verified that the UI now displays dropdown menus for `TeamRole` and `AppRole`.
- [x] **Request Validation**: Successfully processed JSON payloads with string-based enum values.
- [x] **Backward Compatibility**: Confirmed that numeric values are still correctly parsed if provided (default JSON behavior).


## Summary by CodeRabbit

* **Improvements**
  * API enum response fields are now serialized as human-readable string values instead of numeric identifiers, improving consistency and clarity for API integrations and consumer applications.
* **Chores**
  * Updated internal seed data configurations and removed unused code annotations to enhance application maintainability.
---

## 📸 Example Payload
```json
{
  "userEmail": "user1@example.com",
  "roleInTeam": "ClubDirector",
  "isPrimary": true
}
