### PR TITLE
Phase 2 — Player Rostering Implementation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
+- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 - @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
 - @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool, ask the user to enable it.

--- a/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/AddPlayerToRosterHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/AddPlayerToRosterHandlerTests.cs
@@ -1,0 +1,186 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using TTA.BusinessLogic.Features.Rosters.Commands;
+using TTA.BusinessLogic.Features.Rosters.Handlers;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.Rosters.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="AddPlayerToRosterHandler"/> ensuring correct business logic validation
+/// and proper handling of database exceptions.
+/// </summary>
+public class AddPlayerToRosterHandlerTests
+{
+    private readonly Mock<IRosterRepository> _rosterRepoMock;
+    private readonly Mock<ITournamentRepository> _tournamentRepoMock;
+    private readonly Mock<ILogger<AddPlayerToRosterHandler>> _loggerMock;
+    private readonly AddPlayerToRosterHandler _handler;
+
+    public AddPlayerToRosterHandlerTests()
+    {
+        _rosterRepoMock = new Mock<IRosterRepository>();
+        _tournamentRepoMock = new Mock<ITournamentRepository>();
+        _loggerMock = new Mock<ILogger<AddPlayerToRosterHandler>>();
+
+        _handler = new AddPlayerToRosterHandler(
+            _rosterRepoMock.Object,
+            _tournamentRepoMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that a player is successfully added to the roster when the tournament is active.
+    /// </summary>
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldReturnRosterId()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var tournament = new Tournament { Id = command.TournamentId, EndDate = DateTime.UtcNow.AddDays(5) };
+        var rosterItem = command.ToModel();
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        _rosterRepoMock
+            .Setup(x => x.UpsertRosterItemAsync(It.IsAny<PlayerRoster>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rosterItem);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(rosterItem.Id);
+        _rosterRepoMock.Verify(x => x.UpsertRosterItemAsync(It.IsAny<PlayerRoster>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotFoundException"/> is thrown when the tournament does not exist.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TournamentNotFound_ShouldThrowNotFoundException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tournament)null!);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*ID {command.TournamentId}*");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BadRequestException"/> is thrown when the tournament has already ended.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TournamentFinished_ShouldThrowBadRequestException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var finishedTournament = new Tournament { Id = command.TournamentId, EndDate = DateTime.UtcNow.AddDays(-1) };
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(finishedTournament);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BadRequestException>()
+            .WithMessage("Cannot modify rosters for a finished tournament.");
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate jersey number (Postgres error 23505) results in a <see cref="ConflictException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Handle_DuplicateJerseyNumber_ShouldThrowConflictException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        SetupActiveTournament(command.TournamentId);
+
+        var pgException = CreatePostgresException("23505", "Jersey number conflict");
+
+        _rosterRepoMock
+            .Setup(x => x.UpsertRosterItemAsync(It.IsAny<PlayerRoster>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(pgException);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage($"Jersey number {command.Number} is already taken*");
+    }
+
+    /// <summary>
+    /// Verifies that a player already registered in another team (Postgres error P0001) 
+    /// results in a <see cref="ConflictException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Handle_PlayerInAnotherTeam_ShouldThrowConflictException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        SetupActiveTournament(command.TournamentId);
+
+        var pgException = CreatePostgresException("P0001", "Player is already registered for another team in this tournament.");
+
+        _rosterRepoMock
+            .Setup(x => x.UpsertRosterItemAsync(It.IsAny<PlayerRoster>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(pgException);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        // Added wildcard '*' to handle the "P0001: " prefix added by PostgresException
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*Player is already registered for another team in this tournament.*");
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Creates a default command instance for testing.
+    /// </summary>
+    private static AddPlayerToRosterCommand CreateCommand() =>
+        new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 7);
+
+    /// <summary>
+    /// Configures the tournament repository mock to return an active tournament.
+    /// </summary>
+    private void SetupActiveTournament(Guid tournamentId)
+    {
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(tournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Tournament { Id = tournamentId, EndDate = DateTime.UtcNow.AddDays(1) });
+    }
+
+    /// <summary>
+    /// Factory method to create a <see cref="PostgresException"/> for simulation.
+    /// </summary>
+    private static PostgresException CreatePostgresException(string sqlState, string message)
+    {
+        return new PostgresException(
+            messageText: message,
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState);
+    }
+
+    #endregion
+}

--- a/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/GetTeamRosterHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/GetTeamRosterHandlerTests.cs
@@ -11,13 +11,14 @@ using TTA.DataAccess.Repository.Api;
 namespace TTA.BusinessLogic.Tests.Features.Rosters.Handlers;
 
 /// <summary>
-/// Unit tests for the <see cref="GetTeamRosterHandler"/> ensuring correct team validation
+/// Unit tests for the <see cref="GetTeamRosterHandler"/> ensuring correct tournament and team validation
 /// and accurate mapping of dynamic repository results to structured DTOs.
 /// </summary>
 public class GetTeamRosterHandlerTests
 {
     private readonly Mock<IRosterRepository> _rosterRepoMock;
     private readonly Mock<ITeamRepository> _teamRepoMock;
+    private readonly Mock<ITournamentRepository> _tournamentRepoMock;
     private readonly Mock<ILogger<GetTeamRosterHandler>> _loggerMock;
     private readonly GetTeamRosterHandler _handler;
 
@@ -25,30 +26,34 @@ public class GetTeamRosterHandlerTests
     {
         _rosterRepoMock = new Mock<IRosterRepository>();
         _teamRepoMock = new Mock<ITeamRepository>();
+        _tournamentRepoMock = new Mock<ITournamentRepository>();
         _loggerMock = new Mock<ILogger<GetTeamRosterHandler>>();
 
         _handler = new GetTeamRosterHandler(
             _rosterRepoMock.Object,
             _teamRepoMock.Object,
+            _tournamentRepoMock.Object,
             _loggerMock.Object);
     }
 
     /// <summary>
-    /// Verifies that the handler returns a correctly mapped collection of <see cref="RosterPlayerResponse"/>
-    /// when the team exists and has players.
+    /// Verifies that the handler successfully returns a mapped collection of roster players
+    /// when both the tournament and the team exist and contain valid data.
     /// </summary>
     [Fact]
     public async Task Handle_ValidRequest_ShouldReturnMappedRoster()
     {
         // Arrange
         var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
-        var team = new Team { Id = query.TeamId, Name = "Test Team" };
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(query.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Tournament { Id = query.TournamentId });
 
         _teamRepoMock
             .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(team);
+            .ReturnsAsync(new Team { Id = query.TeamId, Name = "Test Team" });
 
-        // Use ExpandoObject to simulate dynamic Dapper results across assembly boundaries
         dynamic row1 = new ExpandoObject();
         row1.id = Guid.NewGuid();
         row1.playerid = Guid.NewGuid();
@@ -58,16 +63,7 @@ public class GetTeamRosterHandlerTests
         row1.positionname = "Forward";
         row1.number = 7;
 
-        dynamic row2 = new ExpandoObject();
-        row2.id = Guid.NewGuid();
-        row2.playerid = Guid.NewGuid();
-        row2.firstname = "Oleksandr";
-        row2.lastname = "Zinchenko";
-        row2.positionid = Guid.NewGuid();
-        row2.positionname = "Midfielder";
-        row2.number = 11;
-
-        var rawData = new List<object> { row1, row2 };
+        var rawData = new List<object> { row1 };
 
         _rosterRepoMock
             .Setup(x => x.GetTeamRosterAsync(query.TournamentId, query.TeamId, It.IsAny<CancellationToken>()))
@@ -77,25 +73,49 @@ public class GetTeamRosterHandlerTests
         var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
 
         // Assert
-        result.Should().HaveCount(2);
-
+        result.Should().HaveCount(1);
         result[0].FirstName.Should().Be("Andriy");
         result[0].Number.Should().Be(7);
-        result[0].PositionName.Should().Be("Forward");
-
-        result[1].FirstName.Should().Be("Oleksandr");
-        result[1].Number.Should().Be(11);
-        result[1].PositionName.Should().Be("Midfielder");
     }
 
     /// <summary>
-    /// Verifies that <see cref="NotFoundException"/> is thrown when the team is not found in the database.
+    /// Ensures that a <see cref="NotFoundException"/> is thrown immediately if the specified 
+    /// tournament does not exist, preventing further team or roster lookups.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TournamentNotFound_ShouldThrowNotFoundException()
+    {
+        // Arrange
+        var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(query.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tournament)null!);
+
+        // Act
+        var act = async () => await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*Tournament with ID {query.TournamentId}*");
+
+        _teamRepoMock.Verify(x => x.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _rosterRepoMock.Verify(x => x.GetTeamRosterAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Ensures that a <see cref="NotFoundException"/> is thrown if the tournament exists 
+    /// but the specified team is not found in the database.
     /// </summary>
     [Fact]
     public async Task Handle_TeamNotFound_ShouldThrowNotFoundException()
     {
         // Arrange
         var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(query.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Tournament { Id = query.TournamentId });
 
         _teamRepoMock
             .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))
@@ -106,20 +126,24 @@ public class GetTeamRosterHandlerTests
 
         // Assert
         await act.Should().ThrowAsync<NotFoundException>()
-            .WithMessage($"*ID {query.TeamId}*");
+            .WithMessage($"*Team with ID {query.TeamId}*");
 
-        _rosterRepoMock.Verify(x => x.GetTeamRosterAsync(
-            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _rosterRepoMock.Verify(x => x.GetTeamRosterAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>
-    /// Verifies that an empty collection is returned if the team exists but has no players assigned.
+    /// Verifies that the handler returns an empty collection instead of throwing an error 
+    /// when the tournament and team are valid but no players are currently registered in the roster.
     /// </summary>
     [Fact]
     public async Task Handle_EmptyRoster_ShouldReturnEmptyCollection()
     {
         // Arrange
         var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(query.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Tournament { Id = query.TournamentId });
 
         _teamRepoMock
             .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))

--- a/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/GetTeamRosterHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/GetTeamRosterHandlerTests.cs
@@ -1,0 +1,138 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Dynamic;
+using TTA.BusinessLogic.Features.Rosters.Handlers;
+using TTA.BusinessLogic.Features.Rosters.Queries;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.Rosters.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="GetTeamRosterHandler"/> ensuring correct team validation
+/// and accurate mapping of dynamic repository results to structured DTOs.
+/// </summary>
+public class GetTeamRosterHandlerTests
+{
+    private readonly Mock<IRosterRepository> _rosterRepoMock;
+    private readonly Mock<ITeamRepository> _teamRepoMock;
+    private readonly Mock<ILogger<GetTeamRosterHandler>> _loggerMock;
+    private readonly GetTeamRosterHandler _handler;
+
+    public GetTeamRosterHandlerTests()
+    {
+        _rosterRepoMock = new Mock<IRosterRepository>();
+        _teamRepoMock = new Mock<ITeamRepository>();
+        _loggerMock = new Mock<ILogger<GetTeamRosterHandler>>();
+
+        _handler = new GetTeamRosterHandler(
+            _rosterRepoMock.Object,
+            _teamRepoMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns a correctly mapped collection of <see cref="RosterPlayerResponse"/>
+    /// when the team exists and has players.
+    /// </summary>
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldReturnMappedRoster()
+    {
+        // Arrange
+        var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+        var team = new Team { Id = query.TeamId, Name = "Test Team" };
+
+        _teamRepoMock
+            .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(team);
+
+        // Use ExpandoObject to simulate dynamic Dapper results across assembly boundaries
+        dynamic row1 = new ExpandoObject();
+        row1.id = Guid.NewGuid();
+        row1.playerid = Guid.NewGuid();
+        row1.firstname = "Andriy";
+        row1.lastname = "Shevchenko";
+        row1.positionid = Guid.NewGuid();
+        row1.positionname = "Forward";
+        row1.number = 7;
+
+        dynamic row2 = new ExpandoObject();
+        row2.id = Guid.NewGuid();
+        row2.playerid = Guid.NewGuid();
+        row2.firstname = "Oleksandr";
+        row2.lastname = "Zinchenko";
+        row2.positionid = Guid.NewGuid();
+        row2.positionname = "Midfielder";
+        row2.number = 11;
+
+        var rawData = new List<object> { row1, row2 };
+
+        _rosterRepoMock
+            .Setup(x => x.GetTeamRosterAsync(query.TournamentId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawData);
+
+        // Act
+        var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+
+        result[0].FirstName.Should().Be("Andriy");
+        result[0].Number.Should().Be(7);
+        result[0].PositionName.Should().Be("Forward");
+
+        result[1].FirstName.Should().Be("Oleksandr");
+        result[1].Number.Should().Be(11);
+        result[1].PositionName.Should().Be("Midfielder");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotFoundException"/> is thrown when the team is not found in the database.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TeamNotFound_ShouldThrowNotFoundException()
+    {
+        // Arrange
+        var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _teamRepoMock
+            .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Team)null!);
+
+        // Act
+        var act = async () => await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*ID {query.TeamId}*");
+
+        _rosterRepoMock.Verify(x => x.GetTeamRosterAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that an empty collection is returned if the team exists but has no players assigned.
+    /// </summary>
+    [Fact]
+    public async Task Handle_EmptyRoster_ShouldReturnEmptyCollection()
+    {
+        // Arrange
+        var query = new GetTeamRosterQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _teamRepoMock
+            .Setup(x => x.GetByIdAsync(query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Team { Id = query.TeamId });
+
+        _rosterRepoMock
+            .Setup(x => x.GetTeamRosterAsync(query.TournamentId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<dynamic>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/RemovePlayerFromRosterHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Rosters/Handlers/RemovePlayerFromRosterHandlerTests.cs
@@ -1,0 +1,109 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.Rosters.Commands;
+using TTA.BusinessLogic.Features.Rosters.Handlers;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.Rosters.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="RemovePlayerFromRosterHandler"/> ensuring correct validation 
+/// of tournament state and proper repository invocation.
+/// </summary>
+public class RemovePlayerFromRosterHandlerTests
+{
+    private readonly Mock<IRosterRepository> _rosterRepoMock;
+    private readonly Mock<ITournamentRepository> _tournamentRepoMock;
+    private readonly Mock<ILogger<RemovePlayerFromRosterHandler>> _loggerMock;
+    private readonly RemovePlayerFromRosterHandler _handler;
+
+    public RemovePlayerFromRosterHandlerTests()
+    {
+        _rosterRepoMock = new Mock<IRosterRepository>();
+        _tournamentRepoMock = new Mock<ITournamentRepository>();
+        _loggerMock = new Mock<ILogger<RemovePlayerFromRosterHandler>>();
+
+        _handler = new RemovePlayerFromRosterHandler(
+            _rosterRepoMock.Object,
+            _tournamentRepoMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that a player is successfully removed from the roster when the tournament is active.
+    /// </summary>
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldInvokeRepository()
+    {
+        // Arrange
+        var command = new RemovePlayerFromRosterCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+        var tournament = new Tournament { Id = command.TournamentId, EndDate = DateTime.UtcNow.AddDays(1) };
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tournament);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _rosterRepoMock.Verify(x => x.RemovePlayerFromRosterAsync(
+            command.TournamentId,
+            command.TeamId,
+            command.PlayerId,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotFoundException"/> is thrown when the tournament does not exist.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TournamentNotFound_ShouldThrowNotFoundException()
+    {
+        // Arrange
+        var command = new RemovePlayerFromRosterCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tournament)null!);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*ID {command.TournamentId}*");
+
+        _rosterRepoMock.Verify(x => x.RemovePlayerFromRosterAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BadRequestException"/> is thrown when attempting 
+    /// to remove a player from a tournament that has already ended.
+    /// </summary>
+    [Fact]
+    public async Task Handle_TournamentFinished_ShouldThrowBadRequestException()
+    {
+        // Arrange
+        var command = new RemovePlayerFromRosterCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+        var finishedTournament = new Tournament { Id = command.TournamentId, EndDate = DateTime.UtcNow.AddDays(-1) };
+
+        _tournamentRepoMock
+            .Setup(x => x.GetByIdAsync(command.TournamentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(finishedTournament);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BadRequestException>()
+            .WithMessage("Cannot modify rosters of a finished tournament.");
+
+        _rosterRepoMock.Verify(x => x.RemovePlayerFromRosterAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/Rosters/Validators/AddPlayerToRosterValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/Rosters/Validators/AddPlayerToRosterValidatorTests.cs
@@ -1,0 +1,105 @@
+﻿using FluentValidation.TestHelper;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+using TTA.BusinessLogic.Features.Rosters.Validators;
+
+namespace TTA.BusinessLogic.Tests.Features.Rosters.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="AddPlayerToRosterValidator"/> ensuring all 
+/// business rules for roster requests are strictly enforced.
+/// </summary>
+public class AddPlayerToRosterValidatorTests
+{
+    private readonly AddPlayerToRosterValidator _validator = new();
+
+    /// <summary>
+    /// Verifies that a valid request passes all validation rules.
+    /// </summary>
+    [Fact]
+    public void Should_Not_Have_Error_When_Request_Is_Valid()
+    {
+        // Arrange
+        var request = new AddPlayerToRosterRequest(
+            PlayerId: Guid.NewGuid(),
+            PositionId: Guid.NewGuid(),
+            Number: 10
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    /// <summary>
+    /// Verifies that an empty PlayerId triggers a validation error.
+    /// </summary>
+    [Fact]
+    public void Should_Have_Error_When_PlayerId_Is_Empty()
+    {
+        // Arrange
+        var request = new AddPlayerToRosterRequest(Guid.Empty, Guid.NewGuid(), 10);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PlayerId)
+            .WithErrorMessage("Player identifier is required.");
+    }
+
+    /// <summary>
+    /// Verifies that an empty PositionId triggers a validation error.
+    /// </summary>
+    [Fact]
+    public void Should_Have_Error_When_PositionId_Is_Empty()
+    {
+        // Arrange
+        var request = new AddPlayerToRosterRequest(Guid.NewGuid(), Guid.Empty, 10);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PositionId)
+            .WithErrorMessage("Position identifier is required.");
+    }
+
+    /// <summary>
+    /// Verifies that a jersey number below the allowed range triggers an error.
+    /// </summary>
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(100)]
+    public void Should_Have_Error_When_Number_Is_Out_Of_Range(int invalidNumber)
+    {
+        // Arrange
+        var request = new AddPlayerToRosterRequest(Guid.NewGuid(), Guid.NewGuid(), invalidNumber);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Number)
+            .WithErrorMessage("Jersey number must be between 0 and 99.");
+    }
+
+    /// <summary>
+    /// Verifies that boundary values for the jersey number are considered valid.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(99)]
+    public void Should_Not_Have_Error_When_Number_Is_On_Boundary(int boundaryNumber)
+    {
+        // Arrange
+        var request = new AddPlayerToRosterRequest(Guid.NewGuid(), Guid.NewGuid(), boundaryNumber);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Number);
+    }
+}

--- a/TTA.BusinessLogic/Features/Rosters/Commands/AddPlayerToRosterCommand.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Commands/AddPlayerToRosterCommand.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+using TTA.DataAccess.Models;
+
+namespace TTA.BusinessLogic.Features.Rosters.Commands;
+
+/// <summary>
+/// Command to assign a player to a specific team's roster within a tournament.
+/// </summary>
+/// <param name="TournamentId">The unique identifier of the tournament.</param>
+/// <param name="TeamId">The unique identifier of the team the player is representing.</param>
+/// <param name="PlayerId">The unique identifier of the player being assigned.</param>
+/// <param name="PositionId">The unique identifier of the assigned player position.</param>
+/// <param name="Number">The jersey number assigned to the player for this tournament.</param>
+public record AddPlayerToRosterCommand(
+    Guid TournamentId,
+    Guid TeamId,
+    Guid PlayerId,
+    Guid PositionId,
+    int Number) : IRequest<Guid>;
+
+/// <summary>
+/// Mapping extensions for <see cref="AddPlayerToRosterCommand"/>.
+/// </summary>
+public static class AddPlayerToRosterCommandExtensions
+{
+    /// <summary>
+    /// Maps the <see cref="AddPlayerToRosterCommand"/> data to a <see cref="PlayerRoster"/> entity.
+    /// </summary>
+    /// <param name="cmd">The command instance.</param>
+    /// <returns>A new <see cref="PlayerRoster"/> entity initialized with command data.</returns>
+    public static PlayerRoster ToModel(this AddPlayerToRosterCommand cmd) => new()
+    {
+        Id = Guid.NewGuid(),
+        TournamentId = cmd.TournamentId,
+        TeamId = cmd.TeamId,
+        PlayerId = cmd.PlayerId,
+        PositionId = cmd.PositionId,
+        Number = cmd.Number,
+        CreatedAt = DateTime.UtcNow
+    };
+}

--- a/TTA.BusinessLogic/Features/Rosters/Commands/RemovePlayerFromRosterCommand.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Commands/RemovePlayerFromRosterCommand.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace TTA.BusinessLogic.Features.Rosters.Commands;
+
+/// <summary>
+/// Command to remove a player from a tournament's roster.
+/// </summary>
+/// <param name="TournamentId">The identifier of the tournament.</param>
+/// <param name="PlayerId">The identifier of the player to remove.</param>
+public record RemovePlayerFromRosterCommand(Guid TournamentId, Guid TeamId, Guid PlayerId) : IRequest;

--- a/TTA.BusinessLogic/Features/Rosters/Commands/RemovePlayerFromRosterCommand.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Commands/RemovePlayerFromRosterCommand.cs
@@ -6,5 +6,6 @@ namespace TTA.BusinessLogic.Features.Rosters.Commands;
 /// Command to remove a player from a tournament's roster.
 /// </summary>
 /// <param name="TournamentId">The identifier of the tournament.</param>
+/// <param name="TeamId">The unique identifier of the team.</param>
 /// <param name="PlayerId">The identifier of the player to remove.</param>
 public record RemovePlayerFromRosterCommand(Guid TournamentId, Guid TeamId, Guid PlayerId) : IRequest;

--- a/TTA.BusinessLogic/Features/Rosters/DTOs/AddPlayerToRosterRequest.cs
+++ b/TTA.BusinessLogic/Features/Rosters/DTOs/AddPlayerToRosterRequest.cs
@@ -5,7 +5,6 @@ namespace TTA.BusinessLogic.Features.Rosters.DTOs;
 /// <summary>
 /// Data transfer object for adding a player to a tournament roster.
 /// </summary>
-/// <param name="TeamId">The unique identifier of the team the player is representing.</param>
 /// <param name="PlayerId">The unique identifier of the player being assigned.</param>
 /// <param name="PositionId">The unique identifier of the assigned player position.</param>
 /// <param name="Number">The jersey number assigned to the player (e.g., 0-99).</param>

--- a/TTA.BusinessLogic/Features/Rosters/DTOs/AddPlayerToRosterRequest.cs
+++ b/TTA.BusinessLogic/Features/Rosters/DTOs/AddPlayerToRosterRequest.cs
@@ -1,0 +1,28 @@
+﻿using TTA.BusinessLogic.Features.Rosters.Commands;
+
+namespace TTA.BusinessLogic.Features.Rosters.DTOs;
+
+/// <summary>
+/// Data transfer object for adding a player to a tournament roster.
+/// </summary>
+/// <param name="TeamId">The unique identifier of the team the player is representing.</param>
+/// <param name="PlayerId">The unique identifier of the player being assigned.</param>
+/// <param name="PositionId">The unique identifier of the assigned player position.</param>
+/// <param name="Number">The jersey number assigned to the player (e.g., 0-99).</param>
+public record AddPlayerToRosterRequest(
+    Guid PlayerId,
+    Guid PositionId,
+    int Number);
+
+/// <summary>
+/// Mapping extensions for <see cref="AddPlayerToRosterRequest"/>.
+/// </summary>
+public static class AddPlayerToRosterRequestExtensions
+{
+    public static AddPlayerToRosterCommand ToCommand(this AddPlayerToRosterRequest request, Guid tournamentId, Guid teamId) => new(
+        TournamentId: tournamentId,
+        TeamId: teamId,
+        PlayerId: request.PlayerId,
+        PositionId: request.PositionId,
+        Number: request.Number);
+}

--- a/TTA.BusinessLogic/Features/Rosters/DTOs/RosterPlayerResponse.cs
+++ b/TTA.BusinessLogic/Features/Rosters/DTOs/RosterPlayerResponse.cs
@@ -1,0 +1,20 @@
+﻿namespace TTA.BusinessLogic.Features.Rosters.DTOs;
+
+/// <summary>
+/// Response data transfer object representing a player within a team's tournament roster.
+/// </summary>
+/// <param name="Id">The unique identifier of the roster entry.</param>
+/// <param name="PlayerId">The unique identifier of the player.</param>
+/// <param name="FirstName">The player's first name.</param>
+/// <param name="LastName">The player's last name.</param>
+/// <param name="PositionId">The identifier of the assigned position definition.</param>
+/// <param name="PositionName">The human-readable name of the position (e.g., Forward, Goalkeeper).</param>
+/// <param name="Number">The jersey number assigned to the player for this tournament.</param>
+public record RosterPlayerResponse(
+    Guid Id,
+    Guid PlayerId,
+    string FirstName,
+    string LastName,
+    Guid PositionId,
+    string PositionName,
+    int Number);

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/AddPlayerToRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/AddPlayerToRosterHandler.cs
@@ -40,7 +40,7 @@ public class AddPlayerToRosterHandler(
         }
 
         // 2. Validate Tournament timeline
-        if (tournament.EndDate < DateTime.UtcNow)
+        if (tournament.EndDate <= DateTime.UtcNow)
         {
             _logger.LogWarning("AddRosterItem failed: Tournament {TournamentId} has already ended.", command.TournamentId);
             throw new BadRequestException("Cannot modify rosters for a finished tournament.");

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/AddPlayerToRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/AddPlayerToRosterHandler.cs
@@ -1,0 +1,70 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using TTA.BusinessLogic.Features.Rosters.Commands;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.Rosters.Handlers;
+
+/// <summary>
+/// Handles the business logic for adding or updating a player in a tournament roster.
+/// Ensures the tournament exists and is still active before persisting changes.
+/// </summary>
+public class AddPlayerToRosterHandler(
+    IRosterRepository rosterRepository,
+    ITournamentRepository tournamentRepository,
+    ILogger<AddPlayerToRosterHandler> logger) : IRequestHandler<AddPlayerToRosterCommand, Guid>
+{
+    private readonly IRosterRepository _rosterRepository = rosterRepository;
+    private readonly ITournamentRepository _tournamentRepository = tournamentRepository;
+    private readonly ILogger<AddPlayerToRosterHandler> _logger = logger;
+
+    /// <summary>
+    /// Handles the roster assignment request.
+    /// </summary>
+    /// <param name="command">The command containing roster assignment details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The unique identifier of the created or updated roster entry.</returns>
+    /// <exception cref="NotFoundException">Thrown when the specified tournament does not exist.</exception>
+    /// <exception cref="BadRequestException">Thrown when attempting to modify a finished tournament.</exception>
+    /// <exception cref="ConflictException">Thrown when jersey number or player registration conflicts occur.</exception>
+    public async Task<Guid> Handle(AddPlayerToRosterCommand command, CancellationToken cancellationToken)
+    {
+        // 1. Validate Tournament existence
+        var tournament = await _tournamentRepository.GetByIdAsync(command.TournamentId, cancellationToken);
+        if (tournament == null)
+        {
+            _logger.LogWarning("AddRosterItem failed: Tournament {TournamentId} not found.", command.TournamentId);
+            throw new NotFoundException($"Tournament with ID {command.TournamentId} was not found.");
+        }
+
+        // 2. Validate Tournament timeline
+        if (tournament.EndDate < DateTime.UtcNow)
+        {
+            _logger.LogWarning("AddRosterItem failed: Tournament {TournamentId} has already ended.", command.TournamentId);
+            throw new BadRequestException("Cannot modify rosters for a finished tournament.");
+        }
+
+        try
+        {
+            var rosterItem = command.ToModel();
+            var result = await _rosterRepository.UpsertRosterItemAsync(rosterItem, cancellationToken);
+
+            _logger.LogInformation("Player {PlayerId} assigned to Team {TeamId} in Tournament {TournamentId}.",
+                command.PlayerId, command.TeamId, command.TournamentId);
+
+            return result.Id;
+        }
+        catch (PostgresException ex) when (ex.SqlState == "23505")
+        {
+            _logger.LogWarning(ex, "Roster conflict: Jersey number {Number} already exists.", command.Number);
+            throw new ConflictException($"Jersey number {command.Number} is already taken in this team roster.");
+        }
+        catch (PostgresException ex) when (ex.SqlState == "P0001")
+        {
+            _logger.LogWarning(ex, "Roster violation: Player {PlayerId} already registered in another team.", command.PlayerId);
+            throw new ConflictException(ex.Message);
+        }
+    }
+}

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
@@ -23,12 +23,12 @@ public class GetTeamRosterHandler(
     private readonly ILogger<GetTeamRosterHandler> _logger = logger;
 
     /// <summary>
-    /// Processes the query to fetch and map the roster data.
+    /// Processes the query to fetch and map the roster data to a collection of <see cref="RosterPlayerResponse"/>.
     /// </summary>
     /// <param name="request">The query containing tournament and team identifiers.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A collection of <see cref="RosterPlayerResponse"/> objects.</returns>
-    /// <exception cref="NotFoundException">Thrown if the team does not exist.</exception>
+    /// <returns>A collection of <see cref="RosterPlayerResponse"/> objects representing the team roster.</returns>
+    /// <exception cref="NotFoundException">Thrown when either the tournament or the team with the specified identifiers was not found.</exception>
     public async Task<IEnumerable<RosterPlayerResponse>> Handle(GetTeamRosterQuery request, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Retrieving roster for Team {TeamId} in Tournament {TournamentId}.",

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
@@ -14,10 +14,12 @@ namespace TTA.BusinessLogic.Features.Rosters.Handlers;
 public class GetTeamRosterHandler(
     IRosterRepository rosterRepository,
     ITeamRepository teamRepository,
+    ITournamentRepository tournamentRepository,
     ILogger<GetTeamRosterHandler> logger) : IRequestHandler<GetTeamRosterQuery, IEnumerable<RosterPlayerResponse>>
 {
     private readonly IRosterRepository _rosterRepository = rosterRepository;
     private readonly ITeamRepository _teamRepository = teamRepository;
+    private readonly ITournamentRepository _tournamentRepository = tournamentRepository;
     private readonly ILogger<GetTeamRosterHandler> _logger = logger;
 
     /// <summary>
@@ -32,7 +34,15 @@ public class GetTeamRosterHandler(
         _logger.LogInformation("Retrieving roster for Team {TeamId} in Tournament {TournamentId}.",
             request.TeamId, request.TournamentId);
 
-        // 1. Check if team exists (optional, but good for precise 404 vs empty list)
+        // 1. Validate Tournament existence
+        var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, cancellationToken);
+        if (tournament == null)
+        {
+            _logger.LogWarning("GetTeamRoster failed: Tournament {TournamentId} not found.", request.TournamentId);
+            throw new NotFoundException($"Tournament with ID {request.TournamentId} was not found.");
+        }
+
+        // 2. Check if team exists (optional, but good for precise 404 vs empty list)
         var team = await _teamRepository.GetByIdAsync(request.TeamId, cancellationToken);
         if (team == null)
         {
@@ -40,11 +50,11 @@ public class GetTeamRosterHandler(
             throw new NotFoundException($"Team with ID {request.TeamId} was not found.");
         }
 
-        // 2. Fetch data from repository
+        // 3. Fetch data from repository
         // We use dynamic results from Dapper to avoid creating an intermediate persistence model
         var rawRoster = await _rosterRepository.GetTeamRosterAsync(request.TournamentId, request.TeamId, cancellationToken);
 
-        // 3. Map dynamic rows to structured DTOs
+        // 4. Map dynamic rows to structured DTOs
         var response = rawRoster.Select(row => new RosterPlayerResponse(
             Id: row.id,
             PlayerId: row.playerid,

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
@@ -1,0 +1,63 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+using TTA.BusinessLogic.Features.Rosters.Queries;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.Rosters.Handlers;
+
+/// <summary>
+/// Handles the retrieval of a specific team's roster for a tournament.
+/// Maps dynamic database results to structured response DTOs.
+/// </summary>
+public class GetTeamRosterHandler(
+    IRosterRepository rosterRepository,
+    ITeamRepository teamRepository,
+    ILogger<GetTeamRosterHandler> logger) : IRequestHandler<GetTeamRosterQuery, IEnumerable<RosterPlayerResponse>>
+{
+    private readonly IRosterRepository _rosterRepository = rosterRepository;
+    private readonly ITeamRepository _teamRepository = teamRepository;
+    private readonly ILogger<GetTeamRosterHandler> _logger = logger;
+
+    /// <summary>
+    /// Processes the query to fetch and map the roster data.
+    /// </summary>
+    /// <param name="request">The query containing tournament and team identifiers.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A collection of <see cref="RosterPlayerResponse"/> objects.</returns>
+    /// <exception cref="NotFoundException">Thrown if the team does not exist.</exception>
+    public async Task<IEnumerable<RosterPlayerResponse>> Handle(GetTeamRosterQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Retrieving roster for Team {TeamId} in Tournament {TournamentId}.",
+            request.TeamId, request.TournamentId);
+
+        // 1. Check if team exists (optional, but good for precise 404 vs empty list)
+        var team = await _teamRepository.GetByIdAsync(request.TeamId, cancellationToken);
+        if (team == null)
+        {
+            _logger.LogWarning("GetTeamRoster failed: Team {TeamId} not found.", request.TeamId);
+            throw new NotFoundException($"Team with ID {request.TeamId} was not found.");
+        }
+
+        // 2. Fetch data from repository
+        // We use dynamic results from Dapper to avoid creating an intermediate persistence model
+        var rawRoster = await _rosterRepository.GetTeamRosterAsync(request.TournamentId, request.TeamId, cancellationToken);
+
+        // 3. Map dynamic rows to structured DTOs
+        var response = rawRoster.Select(row => new RosterPlayerResponse(
+            Id: row.id,
+            PlayerId: row.playerid,
+            FirstName: row.firstname,
+            LastName: row.lastname,
+            PositionId: row.positionid,
+            PositionName: row.positionname,
+            Number: row.number
+        ));
+
+        _logger.LogInformation("Successfully retrieved {Count} players for Team {TeamId}.",
+            response.Count(), request.TeamId);
+
+        return response;
+    }
+}

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/GetTeamRosterHandler.cs
@@ -53,10 +53,10 @@ public class GetTeamRosterHandler(
             PositionId: row.positionid,
             PositionName: row.positionname,
             Number: row.number
-        ));
+        )).ToList();
 
         _logger.LogInformation("Successfully retrieved {Count} players for Team {TeamId}.",
-            response.Count(), request.TeamId);
+            response.Count, request.TeamId);
 
         return response;
     }

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
@@ -7,8 +7,8 @@ using TTA.DataAccess.Repository.Api;
 namespace TTA.BusinessLogic.Features.Rosters.Handlers;
 
 /// <summary>
-/// Handles the business logic for removing a player from a tournament roster.
-/// Verifies tournament status and ownership before execution.
+/// Handler for removing a player from a tournament roster.
+/// Validates tournament existence and end date before removing a player.
 /// </summary>
 public class RemovePlayerFromRosterHandler(
     IRosterRepository rosterRepository,

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
@@ -36,7 +36,7 @@ public class RemovePlayerFromRosterHandler(
             throw new NotFoundException($"Tournament with ID {request.TournamentId} was not found.");
         }
 
-        if (tournament.EndDate < DateTime.UtcNow)
+        if (tournament.EndDate <= DateTime.UtcNow)
         {
             _logger.LogWarning("RemoveRosterItem failed: Tournament {TournamentId} has ended.", request.TournamentId);
             throw new BadRequestException("Cannot modify rosters of a finished tournament.");

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
@@ -23,13 +23,13 @@ public class RemovePlayerFromRosterHandler(
     /// Processes the removal request. Ensures the tournament has not yet ended to maintain data integrity.
     /// </summary>
     /// <param name="request">The command containing tournament and player identifiers.</param>
-    /// <param name="ct">Cancellation token.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     /// <exception cref="NotFoundException">Thrown if the tournament does not exist.</exception>
     /// <exception cref="BadRequestException">Thrown if the tournament timeline is already closed.</exception>
-    public async Task Handle(RemovePlayerFromRosterCommand request, CancellationToken ct)
+    public async Task Handle(RemovePlayerFromRosterCommand request, CancellationToken cancellationToken)
     {
-        var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, ct);
+        var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, cancellationToken);
         if (tournament == null)
         {
             _logger.LogWarning("RemoveRosterItem failed: Tournament {TournamentId} not found.", request.TournamentId);
@@ -42,7 +42,7 @@ public class RemovePlayerFromRosterHandler(
             throw new BadRequestException("Cannot modify rosters of a finished tournament.");
         }
 
-        await _rosterRepository.RemovePlayerFromRosterAsync(request.TournamentId, request.TeamId, request.PlayerId, ct);
+        await _rosterRepository.RemovePlayerFromRosterAsync(request.TournamentId, request.TeamId, request.PlayerId, cancellationToken);
 
         _logger.LogInformation("Player {PlayerId} successfully removed from Tournament {TournamentId}.",
             request.PlayerId, request.TournamentId);

--- a/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Handlers/RemovePlayerFromRosterHandler.cs
@@ -1,0 +1,50 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.Rosters.Commands;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.Rosters.Handlers;
+
+/// <summary>
+/// Handles the business logic for removing a player from a tournament roster.
+/// Verifies tournament status and ownership before execution.
+/// </summary>
+public class RemovePlayerFromRosterHandler(
+    IRosterRepository rosterRepository,
+    ITournamentRepository tournamentRepository,
+    ILogger<RemovePlayerFromRosterHandler> logger) : IRequestHandler<RemovePlayerFromRosterCommand>
+{
+    private readonly IRosterRepository _rosterRepository = rosterRepository;
+    private readonly ITournamentRepository _tournamentRepository = tournamentRepository;
+    private readonly ILogger<RemovePlayerFromRosterHandler> _logger = logger;
+
+    /// <summary>
+    /// Processes the removal request. Ensures the tournament has not yet ended to maintain data integrity.
+    /// </summary>
+    /// <param name="request">The command containing tournament and player identifiers.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <exception cref="NotFoundException">Thrown if the tournament does not exist.</exception>
+    /// <exception cref="BadRequestException">Thrown if the tournament timeline is already closed.</exception>
+    public async Task Handle(RemovePlayerFromRosterCommand request, CancellationToken ct)
+    {
+        var tournament = await _tournamentRepository.GetByIdAsync(request.TournamentId, ct);
+        if (tournament == null)
+        {
+            _logger.LogWarning("RemoveRosterItem failed: Tournament {TournamentId} not found.", request.TournamentId);
+            throw new NotFoundException($"Tournament with ID {request.TournamentId} was not found.");
+        }
+
+        if (tournament.EndDate < DateTime.UtcNow)
+        {
+            _logger.LogWarning("RemoveRosterItem failed: Tournament {TournamentId} has ended.", request.TournamentId);
+            throw new BadRequestException("Cannot modify rosters of a finished tournament.");
+        }
+
+        await _rosterRepository.RemovePlayerFromRosterAsync(request.TournamentId, request.TeamId, request.PlayerId, ct);
+
+        _logger.LogInformation("Player {PlayerId} successfully removed from Tournament {TournamentId}.",
+            request.PlayerId, request.TournamentId);
+    }
+}

--- a/TTA.BusinessLogic/Features/Rosters/Queries/GetTeamRosterQuery.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Queries/GetTeamRosterQuery.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+
+namespace TTA.BusinessLogic.Features.Rosters.Queries;
+
+/// <summary>
+/// Query to retrieve all players assigned to a team's roster for a specific tournament.
+/// </summary>
+/// <param name="TournamentId">The unique identifier of the tournament.</param>
+/// <param name="TeamId">The unique identifier of the team.</param>
+public record GetTeamRosterQuery(Guid TournamentId, Guid TeamId) : IRequest<IEnumerable<RosterPlayerResponse>>;

--- a/TTA.BusinessLogic/Features/Rosters/Validators/AddPlayerToRosterValidator.cs
+++ b/TTA.BusinessLogic/Features/Rosters/Validators/AddPlayerToRosterValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+
+namespace TTA.BusinessLogic.Features.Rosters.Validators;
+
+/// <summary>
+/// Validator for <see cref="AddPlayerToRosterRequest"/> to ensure data integrity before processing.
+/// </summary>
+public class AddPlayerToRosterValidator : AbstractValidator<AddPlayerToRosterRequest>
+{
+    /// <summary>
+    /// Initializes validation rules for the roster request.
+    /// </summary>
+    public AddPlayerToRosterValidator()
+    {
+        RuleFor(x => x.PlayerId)
+            .NotEmpty().WithMessage("Player identifier is required.");
+
+        RuleFor(x => x.PositionId)
+            .NotEmpty().WithMessage("Position identifier is required.");
+
+        RuleFor(x => x.Number)
+            .InclusiveBetween(0, 99).WithMessage("Jersey number must be between 0 and 99.");
+    }
+}

--- a/TTA.BusinessLogic/Features/Teams/Commands/AddTeamMemberCommand.cs
+++ b/TTA.BusinessLogic/Features/Teams/Commands/AddTeamMemberCommand.cs
@@ -7,6 +7,10 @@ namespace TTA.BusinessLogic.Features.Teams.Commands;
 /// <summary>
 /// Command to add or update a user's membership within a team.
 /// </summary>
+/// <param name="TeamId">The unique identifier of the team to which the user is being added.</param>
+/// <param name="UserEmail">The email address of the user to be assigned to the team.</param>
+/// <param name="RoleInTeam">The specific role assigned to the user within the team context (e.g., Player, Coach).</param>
+/// <param name="IsPrimary">Indicates whether this team should be marked as the user's primary team.</param>
 public record AddTeamMemberCommand(
     Guid TeamId,
     string UserEmail,

--- a/TTA.BusinessLogic/Features/Teams/Commands/CreateTeamCommand.cs
+++ b/TTA.BusinessLogic/Features/Teams/Commands/CreateTeamCommand.cs
@@ -6,8 +6,13 @@ using TTA.DataAccess.Models;
 namespace TTA.BusinessLogic.Features.Teams.Commands;
 
 /// <summary>
-/// Command to create a new team, associated with a specific club.
+/// Command to create a new team associated with a specific club.
 /// </summary>
+/// <param name="ClubId">The unique identifier of the club that will own this team.</param>
+/// <param name="Name">The official name of the team.</param>
+/// <param name="SportId">The unique identifier of the sport type the team competes in.</param>
+/// <param name="MinBirthYear">The minimum birth year allowed for team members (optional age restriction).</param>
+/// <param name="Gender">The gender category for the team (e.g., Male, Female, Mixed).</param>
 public record CreateTeamCommand(
     Guid ClubId,
     string Name,

--- a/TTA.BusinessLogic/Features/Teams/DTOs/TeamMemberResponse.cs
+++ b/TTA.BusinessLogic/Features/Teams/DTOs/TeamMemberResponse.cs
@@ -3,6 +3,13 @@
 /// <summary>
 /// Response DTO containing team membership details combined with user profile information.
 /// </summary>
+/// <param name="MembershipId">The unique identifier of the membership record.</param>
+/// <param name="UserId">The unique identifier of the user (from identity provider).</param>
+/// <param name="DisplayName">The user's display name for UI purposes.</param>
+/// <param name="Email">The user's registered email address.</param>
+/// <param name="RoleInTeam">The integer representation of the user's role in the team.</param>
+/// <param name="JoinedAt">The timestamp when the user joined the team.</param>
+/// <param name="IsPrimary">Indicates if this is the user's main team for the sport.</param>
 public record TeamMemberResponse(
     Guid MembershipId,
     string UserId,

--- a/TTA.BusinessLogic/Features/Tournaments/DTOs/TournamentResponse.cs
+++ b/TTA.BusinessLogic/Features/Tournaments/DTOs/TournamentResponse.cs
@@ -5,6 +5,15 @@ namespace TTA.BusinessLogic.Features.Tournaments.DTOs;
 /// <summary>
 /// Data transfer object representing a tournament for API responses.
 /// </summary>
+/// <param name="Id">The unique identifier of the tournament.</param>
+/// <param name="Name">The name of the tournament.</param>
+/// <param name="SportId">The unique identifier of the sport type.</param>
+/// <param name="ConfigurationId">The identifier for specific tournament rules/configuration.</param>
+/// <param name="CityId">The unique identifier of the city where the tournament takes place.</param>
+/// <param name="OwnerId">The unique identifier of the user who owns/created the tournament.</param>
+/// <param name="StartDate">The scheduled start date and time of the tournament.</param>
+/// <param name="EndDate">The scheduled end date and time of the tournament (optional).</param>
+/// <param name="CreatedAt">The timestamp when the tournament record was created.</param>
 public record TournamentResponse(
     Guid Id,
     string Name,

--- a/TTA.DataAccess/Models/PlayerRoster.cs
+++ b/TTA.DataAccess/Models/PlayerRoster.cs
@@ -10,4 +10,5 @@ public class PlayerRoster : IKeyedEntity<Guid>
     public Guid TeamId { get; set; }
     public int Number { get; set; }
     public Guid PositionId { get; set; }
+    public DateTime CreatedAt { get; set; }
 }

--- a/TTA.DataAccess/Repository/Api/IRosterRepository.cs
+++ b/TTA.DataAccess/Repository/Api/IRosterRepository.cs
@@ -29,6 +29,7 @@ public interface IRosterRepository : IEntityRepositoryBase<Guid, PlayerRoster>
     /// Removes a player from a tournament roster.
     /// </summary>
     /// <param name="tournamentId">Tournament identifier.</param>
+    /// <param name="teamId">The unique identifier of the team.</param>
     /// <param name="playerId">Player identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     Task RemovePlayerFromRosterAsync(Guid tournamentId, Guid teamId, Guid playerId, CancellationToken ct = default);

--- a/TTA.DataAccess/Repository/Api/IRosterRepository.cs
+++ b/TTA.DataAccess/Repository/Api/IRosterRepository.cs
@@ -1,0 +1,35 @@
+﻿using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository.Api;
+
+/// <summary>
+/// Defines specialized data access operations for tournament player rosters.
+/// </summary>
+public interface IRosterRepository : IEntityRepositoryBase<Guid, PlayerRoster>
+{
+    /// <summary>
+    /// Adds or updates a player entry in a tournament roster using a database storage function.
+    /// </summary>
+    /// <param name="roster">The roster entity containing assignment details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation, returning the persisted <see cref="PlayerRoster"/>.</returns>
+    Task<PlayerRoster> UpsertRosterItemAsync(PlayerRoster roster, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves all roster entries for a specific team in a tournament.
+    /// </summary>
+    /// <param name="tournamentId">Tournament identifier.</param>
+    /// <param name="teamId">Team identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A collection of roster items with player and position details.</returns>
+    Task<IEnumerable<dynamic>> GetTeamRosterAsync(Guid tournamentId, Guid teamId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a player from a tournament roster.
+    /// </summary>
+    /// <param name="tournamentId">Tournament identifier.</param>
+    /// <param name="playerId">Player identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task RemovePlayerFromRosterAsync(Guid tournamentId, Guid teamId, Guid playerId, CancellationToken ct = default);
+}

--- a/TTA.DataAccess/Repository/RosterRepository.cs
+++ b/TTA.DataAccess/Repository/RosterRepository.cs
@@ -1,0 +1,49 @@
+﻿using Dapper;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository;
+
+/// <summary>
+/// Implements roster management operations for PostgreSQL using Dapper.
+/// </summary>
+/// <param name="connectionFactory">The factory to create database connections.</param>
+public class RosterRepository(IDbConnectionFactory connectionFactory)
+    : EntityRepositoryBase<Guid, PlayerRoster>(connectionFactory), IRosterRepository
+{
+    /// <inheritdoc />
+    public async Task<PlayerRoster> UpsertRosterItemAsync(PlayerRoster roster, CancellationToken ct = default)
+    {
+        return await CreateOrUpdate(roster, SqlStatements.ForRosters.UpsertPlayerToRoster, null, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<dynamic>> GetTeamRosterAsync(Guid tournamentId, Guid teamId, CancellationToken ct = default)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("TournamentId", tournamentId);
+        parameters.Add("TeamId", teamId);
+
+        using var connection = await OpenConnectionAsync(ct);
+        return await connection.QueryAsync<dynamic>(new CommandDefinition(
+            SqlStatements.ForRosters.GetTournamentTeamRoster, parameters, cancellationToken: ct));
+    }
+
+    /// <inheritdoc />
+    public async Task RemovePlayerFromRosterAsync(
+        Guid tournamentId,
+        Guid teamId,
+        Guid playerId,
+        CancellationToken ct = default)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("TournamentId", tournamentId);
+        parameters.Add("TeamId", teamId);
+        parameters.Add("PlayerId", playerId);
+
+        using var connection = await OpenConnectionAsync(ct);
+        await connection.ExecuteAsync(new CommandDefinition(
+            SqlStatements.ForRosters.RemovePlayerFromRoster, parameters, cancellationToken: ct));
+    }
+}

--- a/TTA.DataAccess/Repository/SqlStatements.cs
+++ b/TTA.DataAccess/Repository/SqlStatements.cs
@@ -177,4 +177,30 @@ public static class SqlStatements
         public const string GetTournamentById =
             "SELECT * FROM public.get_tournament_by_id(@p_id)";
     }
+
+    /// <summary>
+    /// Contains SQL command constants for invoking PostgreSQL storage functions related to Rosters.
+    /// </summary>
+    public static class ForRosters
+    {
+        /// <summary>
+        /// SQL to call the upsert function for tournament rosters.
+        /// Matches parameters of public.upsert_player_to_roster.
+        /// </summary>
+        public const string UpsertPlayerToRoster =
+            "SELECT * FROM public.upsert_player_to_roster(@Id, @TournamentId, @TeamId, @PlayerId, @PositionId, @Number, @CreatedAt)";
+
+        /// <summary>
+        /// SQL to retrieve the team roster for a specific tournament.
+        /// Calls public.get_tournament_team_roster.
+        /// </summary>
+        public const string GetTournamentTeamRoster =
+            "SELECT * FROM public.get_tournament_team_roster(@TournamentId, @TeamId)";
+
+        /// <summary>
+        /// SQL to remove a player from a specific tournament roster by tournament and player IDs.
+        /// </summary>
+        public const string RemovePlayerFromRoster =
+            "SELECT public.remove_player_from_roster(@TournamentId, @TeamId, @PlayerId)";
+    }
 }

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -192,12 +192,16 @@ CREATE TABLE playerrosters (
     createdat TIMESTAMPTZ NOT NULL,
     
     -- Added unique constraint to support UPSERT operations.
-    CONSTRAINT uix_playerrosters_full_identity UNIQUE (tournamentid, teamid, playerid)
+    -- CONSTRAINT 1: Ensures a player cannot be registered multiple times for the same team in one tournament.
+    CONSTRAINT uix_playerrosters_player_identity UNIQUE (tournamentid, teamid, playerid),
+    -- CONSTRAINT 2: Ensures jersey numbers are unique within a single team for a specific tournament.
+    -- This prevents race conditions where two different players could be assigned the same number simultaneously.
+    CONSTRAINT uix_playerrosters_jersey_number UNIQUE (tournamentid, teamid, number)
 );
 -- Indexes to speed up searches
 CREATE INDEX ix_playerrosters_tournament ON playerrosters (tournamentid);
 CREATE INDEX ix_playerrosters_team ON playerrosters (teamid);
-
+CREATE INDEX ix_playerrosters_lookup ON public.playerrosters (tournamentid, teamid);
 
 CREATE TABLE matchlineups (
     id UUID PRIMARY KEY,

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -191,14 +191,15 @@ CREATE TABLE playerrosters (
     positionid UUID NOT NULL REFERENCES playerpositiondefinitions(id),
     createdat TIMESTAMPTZ NOT NULL,
     
-    -- Added unique constraint to support UPSERT operations.
     -- CONSTRAINT 1: Ensures a player is registered ONLY ONCE per tournament (across all teams).
     -- This prevents the same player from representing different teams in one tournament.
     CONSTRAINT uix_playerrosters_tournament_player UNIQUE (tournamentid, playerid),
+    
     -- CONSTRAINT 2: Ensures jersey numbers are unique within a single team for a specific tournament.
     -- This handles the race-condition duplicate issue identified by the analysis.
     CONSTRAINT uix_playerrosters_tournament_team_number UNIQUE (tournamentid, teamid, number)
 );
+
 -- Indexes to speed up searches
 CREATE INDEX ix_playerrosters_tournament ON playerrosters (tournamentid);
 CREATE INDEX ix_playerrosters_team ON playerrosters (teamid);

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -188,8 +188,16 @@ CREATE TABLE playerrosters (
     tournamentid UUID NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
     teamid UUID NOT NULL REFERENCES teams(id),
     number INT NOT NULL,
-    positionid UUID NOT NULL REFERENCES playerpositiondefinitions(id)
+    positionid UUID NOT NULL REFERENCES playerpositiondefinitions(id),
+    createdat TIMESTAMPTZ NOT NULL,
+    
+    -- Added unique constraint to support UPSERT operations.
+    CONSTRAINT uix_playerrosters_full_identity UNIQUE (tournamentid, teamid, playerid)
 );
+-- Indexes to speed up searches
+CREATE INDEX ix_playerrosters_tournament ON playerrosters (tournamentid);
+CREATE INDEX ix_playerrosters_team ON playerrosters (teamid);
+
 
 CREATE TABLE matchlineups (
     id UUID PRIMARY KEY,

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -192,11 +192,12 @@ CREATE TABLE playerrosters (
     createdat TIMESTAMPTZ NOT NULL,
     
     -- Added unique constraint to support UPSERT operations.
-    -- CONSTRAINT 1: Ensures a player cannot be registered multiple times for the same team in one tournament.
-    CONSTRAINT uix_playerrosters_player_identity UNIQUE (tournamentid, teamid, playerid),
+    -- CONSTRAINT 1: Ensures a player is registered ONLY ONCE per tournament (across all teams).
+    -- This prevents the same player from representing different teams in one tournament.
+    CONSTRAINT uix_playerrosters_tournament_player UNIQUE (tournamentid, playerid),
     -- CONSTRAINT 2: Ensures jersey numbers are unique within a single team for a specific tournament.
-    -- This prevents race conditions where two different players could be assigned the same number simultaneously.
-    CONSTRAINT uix_playerrosters_jersey_number UNIQUE (tournamentid, teamid, number)
+    -- This handles the race-condition duplicate issue identified by the analysis.
+    CONSTRAINT uix_playerrosters_tournament_team_number UNIQUE (tournamentid, teamid, number)
 );
 -- Indexes to speed up searches
 CREATE INDEX ix_playerrosters_tournament ON playerrosters (tournamentid);

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -202,7 +202,6 @@ CREATE TABLE playerrosters (
 -- Indexes to speed up searches
 CREATE INDEX ix_playerrosters_tournament ON playerrosters (tournamentid);
 CREATE INDEX ix_playerrosters_team ON playerrosters (teamid);
-CREATE INDEX ix_playerrosters_lookup ON public.playerrosters (tournamentid, teamid);
 
 CREATE TABLE matchlineups (
     id UUID PRIMARY KEY,

--- a/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
@@ -534,3 +534,116 @@ BEGIN
     SELECT * FROM public.tournaments WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
+
+-- =============================================================
+-- ROSTER MANAGEMENT FUNCTIONS
+-- =============================================================
+/**
+ * Adds or updates a player's assignment in a specific tournament roster.
+ * * Business Logic:
+ * 1. Ensures the jersey number is unique within the specific team for this tournament.
+ * 2. Validates that a player is not already registered for a DIFFERENT team in the same tournament.
+ * (Players can belong to any club, but can only represent one team per tournament).
+ **/
+CREATE OR REPLACE FUNCTION public.upsert_player_to_roster(
+    p_id UUID,
+    p_tournament_id UUID,
+    p_team_id UUID,
+    p_player_id UUID,
+    p_position_id UUID,
+    p_number INT,
+    p_created_at TIMESTAMPTZ
+)
+RETURNS SETOF public.playerrosters AS $$
+BEGIN
+    -- 1. Validation: Ensure jersey number is unique within THIS team for THIS tournament
+    IF EXISTS (
+        SELECT 1 FROM public.playerrosters 
+        WHERE tournamentid = p_tournament_id 
+          AND teamid = p_team_id 
+          AND number = p_number 
+          AND playerid != p_player_id
+    ) THEN
+        RAISE EXCEPTION 'Jersey number % is already taken in this team roster.', p_number USING ERRCODE = '23505';
+    END IF;
+
+    -- 2. Validation: Ensure player is not playing for another team in the same tournament
+    IF EXISTS (
+        SELECT 1 FROM public.playerrosters 
+        WHERE tournamentid = p_tournament_id 
+          AND playerid = p_player_id
+          AND teamid != p_team_id
+    ) THEN
+        RAISE EXCEPTION 'Player is already registered for another team in this tournament.' USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN QUERY
+    INSERT INTO public.playerrosters (id, tournamentid, teamid, playerid, positionid, number, createdat)
+    VALUES (p_id, p_tournament_id, p_team_id, p_player_id, p_position_id, p_number, p_created_at)
+    ON CONFLICT (tournamentid, teamid, playerid) 
+    DO UPDATE SET 
+        positionid = EXCLUDED.positionid,
+        number = EXCLUDED.number
+    RETURNING *;
+END;
+$$ LANGUAGE plpgsql;
+
+/**
+ * Retrieves the full roster for a specific team in a tournament.
+ * Joins with players and position definitions for a complete view.
+ **/
+CREATE OR REPLACE FUNCTION public.get_tournament_team_roster(
+    p_tournament_id UUID,
+    p_team_id UUID
+)
+RETURNS TABLE (
+    id UUID,
+    tournamentid UUID,
+    teamid UUID,
+    playerid UUID,
+    firstname VARCHAR,
+    lastname VARCHAR,
+    positionid UUID,
+    positionname VARCHAR,
+    number INT,
+    createdat TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        r.id,
+        r.tournamentid,
+        r.teamid,
+        r.playerid,
+        p.firstname,
+        p.lastname,
+        r.positionid,
+        pos.name as positionname,
+        r.number,
+        r.createdat
+    FROM public.playerrosters r
+    INNER JOIN public.players p ON r.playerid = p.id
+    INNER JOIN public.playerpositiondefinitions pos ON r.positionid = pos.id
+    WHERE r.tournamentid = p_tournament_id 
+      AND r.teamid = p_team_id
+    ORDER BY r.number ASC;
+END;
+$$ LANGUAGE plpgsql;
+
+/**
+ * Removes a player from a tournament roster.
+ **/
+CREATE OR REPLACE FUNCTION public.remove_player_from_roster(
+    p_tournament_id UUID,
+    p_team_id UUID,
+    p_player_id UUID
+)
+RETURNS VOID AS $$
+BEGIN
+    DELETE FROM public.playerrosters 
+    WHERE 
+        tournamentid = p_tournament_id 
+        AND teamid = p_team_id
+        AND playerid = p_player_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
@@ -540,10 +540,7 @@ $$ LANGUAGE plpgsql;
 -- =============================================================
 /**
  * Adds or updates a player's assignment in a specific tournament roster.
- * * Business Logic:
- * 1. Ensures the jersey number is unique within the specific team for this tournament.
- * 2. Validates that a player is not already registered for a DIFFERENT team in the same tournament.
- * (Players can belong to any club, but can only represent one team per tournament).
+ * Uses atomic DB constraints instead of race-prone IF EXISTS checks.
  **/
 CREATE OR REPLACE FUNCTION public.upsert_player_to_roster(
     p_id UUID,
@@ -556,35 +553,40 @@ CREATE OR REPLACE FUNCTION public.upsert_player_to_roster(
 )
 RETURNS SETOF public.playerrosters AS $$
 BEGIN
-    -- 1. Validation: Ensure jersey number is unique within THIS team for THIS tournament
-    IF EXISTS (
-        SELECT 1 FROM public.playerrosters 
-        WHERE tournamentid = p_tournament_id 
-          AND teamid = p_team_id 
-          AND number = p_number 
-          AND playerid != p_player_id
-    ) THEN
-        RAISE EXCEPTION 'Jersey number % is already taken in this team roster.', p_number USING ERRCODE = '23505';
-    END IF;
-
-    -- 2. Validation: Ensure player is not playing for another team in the same tournament
-    IF EXISTS (
-        SELECT 1 FROM public.playerrosters 
-        WHERE tournamentid = p_tournament_id 
-          AND playerid = p_player_id
-          AND teamid != p_team_id
-    ) THEN
-        RAISE EXCEPTION 'Player is already registered for another team in this tournament.' USING ERRCODE = 'P0001';
-    END IF;
-
     RETURN QUERY
-    INSERT INTO public.playerrosters (id, tournamentid, teamid, playerid, positionid, number, createdat)
-    VALUES (p_id, p_tournament_id, p_team_id, p_player_id, p_position_id, p_number, p_created_at)
-    ON CONFLICT (tournamentid, teamid, playerid) 
+    INSERT INTO public.playerrosters (
+        id, 
+        tournamentid, 
+        teamid, 
+        playerid, 
+        positionid, 
+        number, 
+        createdat
+    )
+    VALUES (
+        p_id, 
+        p_tournament_id, 
+        p_team_id, 
+        p_player_id, 
+        p_position_id, 
+        p_number, 
+        p_created_at
+    )
+    -- If (tournamentid, playerid) exists, we try to update
+    ON CONFLICT (tournamentid, playerid) 
     DO UPDATE SET 
         positionid = EXCLUDED.positionid,
-        number = EXCLUDED.number
+        number = EXCLUDED.number,
+        -- The update only succeeds if the teamid remains the same.
+        -- If someone tries to move a player to another team via this call,
+        -- the uix_playerrosters_tournament_player will naturally handle the policy.
+        teamid = EXCLUDED.teamid
     RETURNING *;
+
+    /* Note for C# Handler: 
+       Any violation of 'uix_playerrosters_tournament_team_number' (jersey taken)
+       or trying to assign a player to a second team will throw SQLSTATE 23505.
+    */
 END;
 $$ LANGUAGE plpgsql;
 

--- a/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/03-Storage-procedures.sql
@@ -540,7 +540,7 @@ $$ LANGUAGE plpgsql;
 -- =============================================================
 /**
  * Adds or updates a player's assignment in a specific tournament roster.
- * Uses atomic DB constraints instead of race-prone IF EXISTS checks.
+ * Includes a safety check to prevent cross-team player movement within the same tournament.
  **/
 CREATE OR REPLACE FUNCTION public.upsert_player_to_roster(
     p_id UUID,
@@ -553,40 +553,33 @@ CREATE OR REPLACE FUNCTION public.upsert_player_to_roster(
 )
 RETURNS SETOF public.playerrosters AS $$
 BEGIN
+    -- Validation: Check if the player is already registered for a DIFFERENT team in this tournament.
+    -- This prevents silent reassignment and allows the C# Handler to catch SQLSTATE P0001.
+    IF EXISTS (
+        SELECT 1 FROM public.playerrosters 
+        WHERE tournamentid = p_tournament_id 
+          AND playerid = p_player_id
+          AND teamid != p_team_id
+    ) THEN
+        RAISE EXCEPTION 'Player is already registered for another team in this tournament.' 
+        USING ERRCODE = 'P0001';
+    END IF;
+
     RETURN QUERY
     INSERT INTO public.playerrosters (
-        id, 
-        tournamentid, 
-        teamid, 
-        playerid, 
-        positionid, 
-        number, 
-        createdat
+        id, tournamentid, teamid, playerid, positionid, number, createdat
     )
     VALUES (
-        p_id, 
-        p_tournament_id, 
-        p_team_id, 
-        p_player_id, 
-        p_position_id, 
-        p_number, 
-        p_created_at
+        p_id, p_tournament_id, p_team_id, p_player_id, p_position_id, p_number, p_created_at
     )
-    -- If (tournamentid, playerid) exists, we try to update
+    -- Handle existing registration for the SAME team (tournamentid, playerid conflict).
     ON CONFLICT (tournamentid, playerid) 
     DO UPDATE SET 
         positionid = EXCLUDED.positionid,
         number = EXCLUDED.number,
-        -- The update only succeeds if the teamid remains the same.
-        -- If someone tries to move a player to another team via this call,
-        -- the uix_playerrosters_tournament_player will naturally handle the policy.
-        teamid = EXCLUDED.teamid
+        createdat = EXCLUDED.createdat
+        -- teamid is not updated as the IF EXISTS check above ensures it remains the same.
     RETURNING *;
-
-    /* Note for C# Handler: 
-       Any violation of 'uix_playerrosters_tournament_team_number' (jersey taken)
-       or trying to assign a player to a second team will throw SQLSTATE 23505.
-    */
 END;
 $$ LANGUAGE plpgsql;
 

--- a/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
@@ -18,7 +18,7 @@ public class RostersControllerTests(DatabaseFixture fixture, ITestOutputHelper o
     /// <summary>
     /// Gets the base URL for roster operations within a tournament.
     /// </summary>
-    private string GetBaseUrl(Guid tournamentId) => $"api/tournaments/{tournamentId}/rosters";
+    private static string GetBaseUrl(Guid tournamentId) => $"api/tournaments/{tournamentId}/rosters";
 
     /// <summary>
     /// Verifies that the system correctly retrieves the roster for a specific team.

--- a/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
@@ -256,18 +256,35 @@ public class RostersControllerTests(DatabaseFixture fixture, ITestOutputHelper o
     {
         using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
         await conn.OpenAsync();
-        const string countrySql = "INSERT INTO public.countries (name, code) VALUES ('Ukraine', 'UA') ON CONFLICT DO NOTHING RETURNING id";
-        using var countryCmd = new NpgsqlCommand(countrySql, conn);
-        var countryIdObj = await countryCmd.ExecuteScalarAsync();
-        int countryId = countryIdObj != null ? (int)countryIdObj : 1;
 
-        const string regionSql = "INSERT INTO public.regions (countryid, name) VALUES (@cid, 'Integration Region') ON CONFLICT DO NOTHING RETURNING id";
+        // FIX: Use 'DO UPDATE SET name = EXCLUDED.name' to ensure 'RETURNING id' 
+        // always returns the ID, even if the record already exists.
+        const string countrySql = @"
+            INSERT INTO public.countries (name, code) 
+            VALUES ('Ukraine', 'UA') 
+            ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name 
+            RETURNING id";
+
+        using var countryCmd = new NpgsqlCommand(countrySql, conn);
+        var countryId = (int)(await countryCmd.ExecuteScalarAsync())!;
+
+        const string regionSql = @"
+            INSERT INTO public.regions (countryid, name) 
+            VALUES (@cid, 'Integration Region') 
+            ON CONFLICT (countryid, name) DO UPDATE SET name = EXCLUDED.name 
+            RETURNING id";
+
         using var regionCmd = new NpgsqlCommand(regionSql, conn);
         regionCmd.Parameters.AddWithValue("cid", countryId);
-        var regionIdObj = await regionCmd.ExecuteScalarAsync();
-        int regionId = regionIdObj != null ? (int)regionIdObj : 1;
+        var regionId = (int)(await regionCmd.ExecuteScalarAsync())!;
 
-        const string citySql = "INSERT INTO public.cities (id, regionid, name) VALUES (@id, @rid, 'Integration City') ON CONFLICT DO NOTHING";
+        // For City, we use Guid and 'ON CONFLICT DO NOTHING' is fine 
+        // since we already have the cityId from the test Arrange block.
+        const string citySql = @"
+            INSERT INTO public.cities (id, regionid, name) 
+            VALUES (@id, @rid, 'Integration City') 
+            ON CONFLICT (id) DO NOTHING";
+
         using var cityCmd = new NpgsqlCommand(citySql, conn);
         cityCmd.Parameters.AddWithValue("id", cityId);
         cityCmd.Parameters.AddWithValue("rid", regionId);

--- a/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
@@ -111,7 +111,7 @@ public class RostersControllerTests(DatabaseFixture fixture, ITestOutputHelper o
     }
 
     /// <summary>
-    /// Verifies player removal from a roster.
+    /// Verifies player removal from a roster and ensures the state is updated in the database.
     /// </summary>
     [Fact]
     public async Task RemovePlayer_ShouldReturnNoContent_WhenPlayerExistsInRoster()
@@ -121,14 +121,31 @@ public class RostersControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         var tournamentId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
         var playerId = Guid.NewGuid();
+
+        // Seed all dependencies and the roster entry itself
         await SeedRequiredDataForRosterAsync(tournamentId, teamId, playerId, userId);
 
-        // Act
-        // [HttpDelete("{teamId:guid}/{playerId:guid}")]
-        var response = await Client.DeleteAsync($"{GetBaseUrl(tournamentId)}/{teamId}/{playerId}");
+        var deleteUrl = $"{GetBaseUrl(tournamentId)}/{teamId}/{playerId}";
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        // Act: Perform the deletion
+        var deleteResponse = await Client.DeleteAsync(deleteUrl);
+
+        // Assert: Immediate response should be 204 No Content
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Post-condition check: Verify the player is actually gone from the roster
+        // We use the GET endpoint to fetch the current team roster
+        var getRosterUrl = $"{GetBaseUrl(tournamentId)}/{teamId}";
+        var getResponse = await Client.GetAsync(getRosterUrl);
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var roster = await getResponse.Content.ReadFromJsonAsync<List<RosterPlayerResponse>>();
+
+        // Assert that the list does not contain the deleted player
+        roster.Should().NotBeNull();
+        roster.Should().NotContain(p => p.PlayerId == playerId,
+            "because the player should have been removed from the tournament roster");
     }
 
     #region Seeding Helpers

--- a/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/RostersControllerTests.cs
@@ -1,0 +1,345 @@
+﻿using FluentAssertions;
+using Npgsql;
+using System.Net;
+using System.Net.Http.Json;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+using TTA.Tests.Integration.Infrastructure;
+using Xunit.Abstractions;
+
+namespace TTA.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for the RostersController.
+/// Validates roster management while ensuring proper authorization and data integrity.
+/// </summary>
+public class RostersControllerTests(DatabaseFixture fixture, ITestOutputHelper output)
+    : BaseApiTest(fixture, output)
+{
+    /// <summary>
+    /// Gets the base URL for roster operations within a tournament.
+    /// </summary>
+    private string GetBaseUrl(Guid tournamentId) => $"api/tournaments/{tournamentId}/rosters";
+
+    /// <summary>
+    /// Verifies that the system correctly retrieves the roster for a specific team.
+    /// Route: GET api/tournaments/{tournamentId}/rosters/{teamId}
+    /// </summary>
+    [Fact]
+    public async Task GetTeamRoster_ShouldReturnOk_WhenRosterExists()
+    {
+        // Arrange
+        var userId = await SeedUserAsync(TestUserId);
+        var tournamentId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        await SeedRequiredDataForRosterAsync(tournamentId, teamId, playerId, userId);
+
+        // Act
+        var response = await Client.GetAsync($"{GetBaseUrl(tournamentId)}/{teamId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<RosterPlayerResponse>>();
+        result.Should().NotBeNull();
+        result.Should().Contain(p => p.PlayerId == playerId);
+    }
+
+    /// <summary>
+    /// Validates that a player can be added to a tournament team roster.
+    /// Requires TeamEditor policy (Role <= 1).
+    /// </summary>
+    [Fact]
+    public async Task AddPlayer_ShouldReturnCreated_WhenRequestIsValid()
+    {
+        // Arrange
+        var userId = await SeedUserAsync(TestUserId);
+        var tournamentId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        var clubId = await SeedRequiredDataForRosterAsync(tournamentId, teamId, playerId, userId);
+
+        var newPlayerId = Guid.NewGuid();
+        await SeedPlayerAsync(newPlayerId, "Jane", "Smith", clubId);
+
+        var sportId = await GetSportIdByTournament(tournamentId);
+        var positionId = await SeedPositionAsync(sportId, "Midfielder", "MF");
+
+        var request = new AddPlayerToRosterRequest(
+            PlayerId: newPlayerId,
+            PositionId: positionId,
+            Number: 99
+        );
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"{GetBaseUrl(tournamentId)}/{teamId}", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    /// <summary>
+    /// Ensures Conflict is returned when a jersey number is already taken in the team.
+    /// Validates that authorization passes before business logic conflict is checked.
+    /// </summary>
+    [Fact]
+    public async Task AddPlayer_ShouldReturnConflict_WhenJerseyNumberIsTaken()
+    {
+        // Arrange
+        var userId = await SeedUserAsync(TestUserId);
+        var tournamentId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        var clubId = await SeedRequiredDataForRosterAsync(tournamentId, teamId, playerId, userId);
+
+        var newPlayerId = Guid.NewGuid();
+        await SeedPlayerAsync(newPlayerId, "Duplicate", "Number", clubId);
+
+        var sportId = await GetSportIdByTournament(tournamentId);
+        var positionId = await SeedPositionAsync(sportId, "Defender", "DF");
+
+        var request = new AddPlayerToRosterRequest(
+            PlayerId: newPlayerId,
+            PositionId: positionId,
+            Number: 10 // Pre-seeded number from SeedRequiredDataForRosterAsync
+        );
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"{GetBaseUrl(tournamentId)}/{teamId}", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    /// <summary>
+    /// Verifies player removal from a roster.
+    /// </summary>
+    [Fact]
+    public async Task RemovePlayer_ShouldReturnNoContent_WhenPlayerExistsInRoster()
+    {
+        // Arrange
+        var userId = await SeedUserAsync(TestUserId);
+        var tournamentId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        await SeedRequiredDataForRosterAsync(tournamentId, teamId, playerId, userId);
+
+        // Act
+        // [HttpDelete("{teamId:guid}/{playerId:guid}")]
+        var response = await Client.DeleteAsync($"{GetBaseUrl(tournamentId)}/{teamId}/{playerId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    #region Seeding Helpers
+
+    /// <summary>
+    /// Seeds the full dependency graph for a roster test case including authorization policies.
+    /// </summary>
+    private async Task<Guid> SeedRequiredDataForRosterAsync(Guid tournamentId, Guid teamId, Guid playerId, string userId)
+    {
+        var cityId = Guid.NewGuid();
+        var sportId = Guid.NewGuid();
+        var clubId = Guid.NewGuid();
+
+        await SeedRequiredLocationDataAsync(cityId);
+        await SeedSportDataAsync(sportId, "Football");
+        var configId = await SeedConfigurationAsync(sportId);
+
+        await SeedClubAsync(clubId, cityId);
+        await SeedTeamAsync(teamId, "Test Team", sportId, clubId);
+        await SeedTournamentAsync(tournamentId, sportId, configId, cityId, userId, "Test Tournament");
+
+        // IMPORTANT: Seed access policy so AccessService returns a valid role (Editor = 1)
+        // TargetType 2 corresponds to TargetScope.Team
+        await SeedAccessPolicyAsync(userId, teamId, 2, 1);
+
+        var positionId = await SeedPositionAsync(sportId, "Forward", "FW");
+        await SeedPlayerAsync(playerId, "First", "Last", clubId);
+        await SeedPlayerRosterAsync(tournamentId, teamId, playerId, positionId, 10);
+
+        return clubId;
+    }
+
+    /// <summary>
+    /// Seeds an access policy in the auth schema to allow the test user to perform actions.
+    /// </summary>
+    /// <param name="userId">The ID of the user.</param>
+    /// <param name="targetId">The ID of the Team or Club.</param>
+    /// <param name="targetType">0: Global, 1: Club, 2: Team.</param>
+    /// <param name="role">0: FullControl, 1: Editor, 2: Viewer.</param>
+    private async Task SeedAccessPolicyAsync(string userId, Guid targetId, int targetType, int role)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = @"
+            INSERT INTO auth.accesspolicies (id, userid, role, targettype, targetid, createdat) 
+            VALUES (@id, @userId, @role, @targetType, @targetId, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("userId", userId);
+        cmd.Parameters.AddWithValue("role", role);
+        cmd.Parameters.AddWithValue("targetType", targetType);
+        cmd.Parameters.AddWithValue("targetId", targetId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedTournamentAsync(Guid id, Guid sportId, Guid configId, Guid cityId, string userId, string name)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = @"
+            INSERT INTO public.tournaments (id, sportid, configurationid, cityid, ownerid, name, startdate, enddate, createdat) 
+            VALUES (@id, @sportId, @configId, @cityId, @userId, @name, @start, @end, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("sportId", sportId);
+        cmd.Parameters.AddWithValue("configId", configId);
+        cmd.Parameters.AddWithValue("cityId", cityId);
+        cmd.Parameters.AddWithValue("userId", userId);
+        cmd.Parameters.AddWithValue("name", name);
+        cmd.Parameters.AddWithValue("start", DateTime.UtcNow.AddDays(-1));
+        cmd.Parameters.AddWithValue("end", DateTime.UtcNow.AddDays(7));
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedPlayerAsync(Guid id, string f, string l, Guid clubId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = @"
+            INSERT INTO public.players (id, homeclubid, firstname, lastname, birthdate, gender, createdat) 
+            VALUES (@id, @clubId, @f, @l, @dob, @gender, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("clubId", clubId);
+        cmd.Parameters.AddWithValue("f", f);
+        cmd.Parameters.AddWithValue("l", l);
+        cmd.Parameters.AddWithValue("dob", new DateTime(1995, 1, 1));
+        cmd.Parameters.AddWithValue("gender", 0);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedPositionAsync(Guid sportId, string name, string shortName)
+    {
+        var id = Guid.NewGuid();
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.playerpositiondefinitions (id, sportid, name, shortname) VALUES (@id, @sId, @name, @sn)";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("sId", sportId);
+        cmd.Parameters.AddWithValue("name", name);
+        cmd.Parameters.AddWithValue("sn", shortName);
+        await cmd.ExecuteNonQueryAsync();
+        return id;
+    }
+
+    private async Task SeedRequiredLocationDataAsync(Guid cityId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string countrySql = "INSERT INTO public.countries (name, code) VALUES ('Ukraine', 'UA') ON CONFLICT DO NOTHING RETURNING id";
+        using var countryCmd = new NpgsqlCommand(countrySql, conn);
+        var countryIdObj = await countryCmd.ExecuteScalarAsync();
+        int countryId = countryIdObj != null ? (int)countryIdObj : 1;
+
+        const string regionSql = "INSERT INTO public.regions (countryid, name) VALUES (@cid, 'Integration Region') ON CONFLICT DO NOTHING RETURNING id";
+        using var regionCmd = new NpgsqlCommand(regionSql, conn);
+        regionCmd.Parameters.AddWithValue("cid", countryId);
+        var regionIdObj = await regionCmd.ExecuteScalarAsync();
+        int regionId = regionIdObj != null ? (int)regionIdObj : 1;
+
+        const string citySql = "INSERT INTO public.cities (id, regionid, name) VALUES (@id, @rid, 'Integration City') ON CONFLICT DO NOTHING";
+        using var cityCmd = new NpgsqlCommand(citySql, conn);
+        cityCmd.Parameters.AddWithValue("id", cityId);
+        cityCmd.Parameters.AddWithValue("rid", regionId);
+        await cityCmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedClubAsync(Guid id, Guid cityId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.clubs (id, name, cityid, createdat) VALUES (@id, 'Test Club', @cityId, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("cityId", cityId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedTeamAsync(Guid id, string name, Guid sportId, Guid clubId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.teams (id, clubid, sportid, name, gender, createdat) VALUES (@id, @clubId, @sportId, @name, 0, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("clubId", clubId);
+        cmd.Parameters.AddWithValue("sportId", sportId);
+        cmd.Parameters.AddWithValue("name", name);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedConfigurationAsync(Guid sportId)
+    {
+        var configId = Guid.NewGuid();
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.sportconfigurations (id, sportid, usescleantime, periodscount, perioddurationminutes, fieldsize, rosterlimit, lineuplimit) VALUES (@id, @sportId, false, 2, 45, 'Standard', 25, 11)";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", configId);
+        cmd.Parameters.AddWithValue("sportId", sportId);
+        await cmd.ExecuteNonQueryAsync();
+        return configId;
+    }
+
+    private async Task SeedPlayerRosterAsync(Guid tId, Guid teamId, Guid pId, Guid posId, int number)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.playerrosters (id, tournamentid, teamid, playerid, positionid, number, createdat) VALUES (@id, @tId, @teamId, @pId, @posId, @num, NOW())";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("tId", tId);
+        cmd.Parameters.AddWithValue("teamId", teamId);
+        cmd.Parameters.AddWithValue("pId", pId);
+        cmd.Parameters.AddWithValue("posId", posId);
+        cmd.Parameters.AddWithValue("num", number);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<string> SeedUserAsync(string userId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.users (id, email, displayname, createdat) VALUES (@id, @email, 'Tester', NOW()) ON CONFLICT DO NOTHING";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", userId);
+        cmd.Parameters.AddWithValue("email", $"test_{userId}@example.com");
+        await cmd.ExecuteNonQueryAsync();
+        return userId;
+    }
+
+    private async Task SeedSportDataAsync(Guid id, string name)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "INSERT INTO public.sports (id, name) VALUES (@id, @name) ON CONFLICT DO NOTHING";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("name", name);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> GetSportIdByTournament(Guid tournamentId)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+        const string sql = "SELECT sportid FROM public.tournaments WHERE id = @id";
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", tournamentId);
+        return (Guid)(await cmd.ExecuteScalarAsync())!;
+    }
+    #endregion
+}

--- a/TTA.Tests.Integration/Repository/RosterRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/RosterRepositoryTests.cs
@@ -1,0 +1,267 @@
+﻿using Dapper;
+using FluentAssertions;
+using Npgsql;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository;
+using TTA.Tests.Integration.Infrastructure;
+
+namespace TTA.Tests.Integration.Repository;
+
+/// <summary>
+/// Integration tests for <see cref="RosterRepository"/> verifying roster management logic,
+/// database constraints, and stored procedure behavior.
+/// </summary>
+public class RosterRepositoryTests : BaseIntegrationTest
+{
+    private readonly RosterRepository _repository;
+
+    public RosterRepositoryTests(DatabaseFixture fixture) : base(fixture)
+    {
+        _repository = new RosterRepository(fixture.ConnectionFactory);
+    }
+
+    #region Upsert & Constraints Tests
+
+    /// <summary>
+    /// Verifies that <see cref="RosterRepository.UpsertRosterItemAsync"/> correctly inserts 
+    /// a new player record into the roster.
+    /// </summary>
+    [Fact]
+    public async Task UpsertRosterItemAsync_ShouldPersistNewPlayer()
+    {
+        // Arrange
+        var (tournamentId, teamId, sportId, clubId) = await SeedTournamentContextAsync();
+        var playerId = await SeedPlayerAsync(clubId);
+        var positionId = await SeedPositionAsync(sportId);
+
+        var rosterEntry = CreateModel(tournamentId, teamId, playerId, positionId, 10);
+
+        // Act
+        var result = await _repository.UpsertRosterItemAsync(rosterEntry);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Number.Should().Be(10);
+
+        var dbContent = (await GetRawRosterAsync(tournamentId)).ToList();
+        dbContent.Should().ContainSingle();
+
+        var row = (IDictionary<string, object>)dbContent.First();
+        row["playerid"].Should().Be(playerId);
+        row["number"].Should().Be(10);
+    }
+
+    /// <summary>
+    /// Verifies that updating an existing roster entry (same player, same tournament) 
+    /// works as an Upsert via the storage function.
+    /// </summary>
+    [Fact]
+    public async Task UpsertRosterItemAsync_ShouldUpdateExistingEntry_WhenPlayerAlreadyInTournament()
+    {
+        // Arrange
+        var (tournamentId, teamId, sportId, clubId) = await SeedTournamentContextAsync();
+        var playerId = await SeedPlayerAsync(clubId);
+        var positionId = await SeedPositionAsync(sportId);
+
+        await _repository.UpsertRosterItemAsync(CreateModel(tournamentId, teamId, playerId, positionId, 10));
+
+        // Act: Update jersey number for the same player in the same tournament
+        var updatedEntry = CreateModel(tournamentId, teamId, playerId, positionId, 99);
+        await _repository.UpsertRosterItemAsync(updatedEntry);
+
+        // Assert
+        var dbContent = (await GetRawRosterAsync(tournamentId)).ToList();
+        dbContent.Should().ContainSingle();
+        var row = (IDictionary<string, object>)dbContent.First();
+        row["number"].Should().Be(99);
+    }
+
+    /// <summary>
+    /// Validates the business logic within the storage function that prevents 
+    /// duplicate jersey numbers within the same team.
+    /// </summary>
+    [Fact]
+    public async Task UpsertRosterItemAsync_ShouldThrow_WhenJerseyNumberIsDuplicateInSameTeam()
+    {
+        // Arrange
+        var (tournamentId, teamId, sportId, clubId) = await SeedTournamentContextAsync();
+        var posId = await SeedPositionAsync(sportId);
+
+        var playerA = await SeedPlayerAsync(clubId);
+        await _repository.UpsertRosterItemAsync(CreateModel(tournamentId, teamId, playerA, posId, 7));
+
+        // Act & Assert
+        var playerB = await SeedPlayerAsync(clubId);
+        var duplicateNumberEntry = CreateModel(tournamentId, teamId, playerB, posId, 7);
+
+        var act = async () => await _repository.UpsertRosterItemAsync(duplicateNumberEntry);
+
+        // Expecting 23505 (Unique Violation) as raised by the storage function validation block
+        await act.Should().ThrowAsync<PostgresException>()
+            .Where(e => e.SqlState == "23505");
+    }
+
+    #endregion
+
+    #region Retrieval & Deletion Tests
+
+    /// <summary>
+    /// Verifies that <see cref="RosterRepository.GetTeamRosterAsync"/> returns joined data 
+    /// including player names and position names.
+    /// </summary>
+    [Fact]
+    public async Task GetTeamRosterAsync_ShouldReturnJoinedData()
+    {
+        // Arrange
+        var (tournamentId, teamId, sportId, clubId) = await SeedTournamentContextAsync();
+        var playerId = await SeedPlayerAsync(clubId, "Andriy", "Shevchenko");
+        var posId = await SeedPositionAsync(sportId, "Forward", "FW");
+        await _repository.UpsertRosterItemAsync(CreateModel(tournamentId, teamId, playerId, posId, 7));
+
+        // Act
+        var result = (await _repository.GetTeamRosterAsync(tournamentId, teamId)).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        var row = (IDictionary<string, object>)result.First();
+        row["firstname"].Should().Be("Andriy");
+        row["lastname"].Should().Be("Shevchenko");
+        row["positionname"].Should().Be("Forward");
+        row["number"].Should().Be(7);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RosterRepository.RemovePlayerFromRosterAsync"/> removes the assignment.
+    /// </summary>
+    [Fact]
+    public async Task RemovePlayerFromRosterAsync_ShouldDeleteRecord()
+    {
+        // Arrange
+        var (tournamentId, teamId, sportId, clubId) = await SeedTournamentContextAsync();
+        var playerId = await SeedPlayerAsync(clubId);
+        var posId = await SeedPositionAsync(sportId);
+        await _repository.UpsertRosterItemAsync(CreateModel(tournamentId, teamId, playerId, posId, 1));
+
+        // Act
+        await _repository.RemovePlayerFromRosterAsync(tournamentId, teamId, playerId);
+
+        // Assert
+        var dbContent = await GetRawRosterAsync(tournamentId);
+        dbContent.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Helpers & Seeding
+
+    /// <summary>
+    /// Seeds the full hierarchy required to create a valid Tournament and Team according to 01-Tables.sql.
+    /// </summary>
+    private async Task<(Guid tournamentId, Guid teamId, Guid sportId, Guid clubId)> SeedTournamentContextAsync()
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var unique = Guid.NewGuid().ToString("N")[..8];
+
+        var countryId = await conn.ExecuteScalarAsync<int>(
+            "INSERT INTO public.countries (name, code, createdat) VALUES (@n, @c, now()) RETURNING id",
+            new { n = "Country_" + unique, c = unique[..3].ToUpper() });
+
+        var regionId = await conn.ExecuteScalarAsync<int>(
+            "INSERT INTO public.regions (countryid, name) VALUES (@countryId, @n) RETURNING id",
+            new { countryId, n = "Region_" + unique });
+
+        var cityId = Guid.NewGuid();
+        await conn.ExecuteAsync(
+            "INSERT INTO public.cities (id, regionid, name) VALUES (@id, @regionId, @n)",
+            new { id = cityId, regionId, n = "City_" + unique });
+
+        var ownerId = "auth0|test-owner-" + unique;
+        await conn.ExecuteAsync(
+            "INSERT INTO public.users (id, email, displayname, createdat) VALUES (@ownerId, @e, @n, now())",
+            new { ownerId, e = $"owner_{unique}@test.com", n = "Owner" + unique });
+
+        var sportId = Guid.NewGuid();
+        await conn.ExecuteAsync(
+            "INSERT INTO public.sports (id, name) VALUES (@id, @n)",
+            new { id = sportId, n = "Sport_" + unique });
+
+        var configId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.sportconfigurations 
+            (id, sportid, usescleantime, periodscount, perioddurationminutes, fieldsize, rosterlimit, lineuplimit) 
+            VALUES (@id, @sportId, true, 2, 45, 'Standard', 25, 11)",
+            new { id = configId, sportId });
+
+        var clubId = Guid.NewGuid();
+        await conn.ExecuteAsync(
+            "INSERT INTO public.clubs (id, cityid, name, createdat) VALUES (@id, @cityId, @n, now())",
+            new { id = clubId, cityId, n = "Club_" + unique });
+
+        var teamId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.teams (id, clubid, sportid, name, gender, createdat) 
+            VALUES (@id, @clubId, @sportId, @n, 0, now())",
+            new { id = teamId, clubId, sportId, n = "Team_" + unique });
+
+        var tournamentId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.tournaments (id, sportid, configurationid, cityid, ownerid, name, startdate, createdat) 
+            VALUES (@id, @sportId, @configId, @cityId, @ownerId, @n, now(), now())",
+            new { id = tournamentId, sportId, configId, cityId, ownerId, n = "Tournament_" + unique });
+
+        return (tournamentId, teamId, sportId, clubId);
+    }
+
+    /// <summary>
+    /// Seeds a player record. References homeclubid as per schema.
+    /// </summary>
+    private async Task<Guid> SeedPlayerAsync(Guid clubId, string fn = "John", string ln = "Doe")
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var id = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.players (id, homeclubid, firstname, lastname, birthdate, gender, createdat) 
+            VALUES (@id, @clubId, @fn, @ln, '2000-01-01', 0, now())",
+            new { id, clubId, fn, ln });
+        return id;
+    }
+
+    /// <summary>
+    /// Seeds a position definition. Requires shortname as per schema.
+    /// </summary>
+    private async Task<Guid> SeedPositionAsync(Guid sportId, string name = "Defender", string shortName = "DF")
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var id = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.playerpositiondefinitions (id, sportid, name, shortname) 
+            VALUES (@id, @sportId, @name, @shortName)",
+            new { id, sportId, name, shortName });
+        return id;
+    }
+
+    /// <summary>
+    /// Queries the playerrosters table directly to verify results.
+    /// </summary>
+    private async Task<IEnumerable<dynamic>> GetRawRosterAsync(Guid tournamentId)
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        return await conn.QueryAsync("SELECT * FROM public.playerrosters WHERE tournamentid = @tournamentId", new { tournamentId });
+    }
+
+    /// <summary>
+    /// Factory method for <see cref="PlayerRoster"/> model.
+    /// </summary>
+    private static PlayerRoster CreateModel(Guid tId, Guid teamId, Guid pId, Guid posId, int num) => new()
+    {
+        Id = Guid.NewGuid(),
+        TournamentId = tId,
+        TeamId = teamId,
+        PlayerId = pId,
+        PositionId = posId,
+        Number = num,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    #endregion
+}

--- a/TTA.WebAPI/Controllers/RostersController.cs
+++ b/TTA.WebAPI/Controllers/RostersController.cs
@@ -1,0 +1,119 @@
+﻿using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TTA.BusinessLogic.Features.Rosters.Commands;
+using TTA.BusinessLogic.Features.Rosters.DTOs;
+using TTA.BusinessLogic.Features.Rosters.Queries;
+
+namespace TTA.WebAPI.Controllers;
+
+/// <summary>
+/// Controller for managing player rosters within the context of specific tournaments.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="RostersController"/> class.
+/// </remarks>
+/// <param name="mediator">The mediator instance for dispatching commands.</param>
+/// <param name="logger">The logger instance for diagnostic information.</param>
+[Authorize]
+[ApiController]
+[Route("api/tournaments/{tournamentId:guid}/rosters")]
+public class RostersController(
+    IMediator mediator,
+    ILogger<RostersController> logger) : ControllerBase
+{
+    private readonly IMediator _mediator = mediator;
+    private readonly ILogger<RostersController> _logger = logger;
+
+    /// <summary>
+    /// Registers a player to a team's roster for the specified tournament.
+    /// </summary>
+    /// <param name="tournamentId">The unique identifier of the tournament (from route).</param>
+    ///  <param name="teamId">The team identifier.</param>
+    /// <param name="request">The roster assignment details.</param>
+    /// <param name="validator">The validator for the incoming request.</param>
+    /// <returns>The unique identifier of the created roster record.</returns>
+    /// <response code="201">Successfully assigned the player to the roster.</response>
+    /// <response code="400">If the tournament has ended or the request data fails validation.</response>
+    /// <response code="404">If the tournament, team, or player was not found.</response>
+    /// <response code="409">If there is a conflict with jersey numbers or player registration.</response>
+    [Authorize(Policy = "TeamEditor")]
+    [HttpPost("{teamId:guid}")]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> AddPlayer(
+        [FromRoute] Guid tournamentId,
+        [FromRoute] Guid teamId,
+        [FromBody] AddPlayerToRosterRequest request,
+        [FromServices] IValidator<AddPlayerToRosterRequest> validator)
+    {
+        _logger.LogInformation("Validating and processing roster assignment for Player {PlayerId} in Team {TeamId} for Tournament {TournamentId}.",
+            request.PlayerId, teamId, tournamentId);
+
+        // 1. Validate the request DTO using the injected validator
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for AddPlayerToRosterRequest: {Errors}.", validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Map DTO and Route param to Command
+        var command = request.ToCommand(tournamentId, teamId);
+
+        // 3. Dispatch to Handler
+        var result = await _mediator.Send(command);
+
+        _logger.LogInformation("Successfully created roster assignment {RosterId} for Tournament {TournamentId}.",
+            result, tournamentId);
+
+        return StatusCode(StatusCodes.Status201Created, result);
+    }
+
+    /// <summary>
+    /// Retrieves the roster for a specific team in the tournament.
+    /// </summary>
+    /// <param name="tournamentId">The tournament identifier.</param>
+    /// <param name="teamId">The team identifier.</param>
+    /// <response code="200">Returns the team roster.</response>
+    [AllowAnonymous]
+    [HttpGet("{teamId:guid}")]
+    [ProducesResponseType(typeof(IEnumerable<RosterPlayerResponse>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetTeamRoster(
+        [FromRoute] Guid tournamentId,
+        [FromRoute] Guid teamId)
+    {
+        _logger.LogInformation("Fetching roster for Team {TeamId} in Tournament {TournamentId}.", teamId, tournamentId);
+
+        var query = new GetTeamRosterQuery(tournamentId, teamId);
+        var result = await _mediator.Send(query);
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Removes a player from the tournament roster.
+    /// </summary>
+    /// <param name="tournamentId">The tournament identifier.</param>
+    /// <param name="teamId">The team identifier.</param>
+    /// <param name="playerId">The player identifier.</param>
+    /// <response code="204">Player successfully removed.</response>
+    [Authorize(Policy = "TeamEditor")]
+    [HttpDelete("{teamId:guid}/{playerId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> RemovePlayer(
+        [FromRoute] Guid tournamentId,
+        [FromRoute] Guid teamId,
+        [FromRoute] Guid playerId)
+    {
+        _logger.LogInformation("Removing player {PlayerId} from team {TeamId} in tournament {TournamentId}.", playerId, teamId, tournamentId);
+
+        await _mediator.Send(new RemovePlayerFromRosterCommand(tournamentId, teamId, playerId));
+
+        return NoContent();
+    }
+}

--- a/TTA.WebAPI/Startup.cs
+++ b/TTA.WebAPI/Startup.cs
@@ -119,6 +119,7 @@ public static class Startup
         services.AddScoped<ITeamRepository, TeamRepository>();
         services.AddScoped<ITeamMembershipRepository, TeamMembershipRepository>();
         services.AddScoped<ITournamentRepository, TournamentRepository>();
+        services.AddScoped<IRosterRepository, RosterRepository>();
 
         services.AddSingleton<IDbConnectionFactory, NpgsqlConnectionFactory>();
 


### PR DESCRIPTION
# 🏆 Pull Request: Phase 2 — Player Rostering Implementation

## 📝 Description
This PR implements the **Player Rostering** logic, serving as the essential "Link" layer between Players, Teams, and Tournaments. It introduces comprehensive roster management, including business validation for jersey numbers, player positions, and secure access control.

## 🚀 Key Changes

### 🏗️ Database Layer (Dapper & SQL)
- Created the `PlayerRoster` data model in `TTA.DataAccess.Models`.
- Implemented `RosterRepository` for high-performance data operations using Dapper.
- Added SQL constants and logic in `SqlStatements.ForRosters`.
- Implemented robust PL/pgSQL functions in `03-Storage-procedures.sql`:
  - `public.add_player_to_roster`: Handles UPSERT logic for roster assignments.
  - `public.remove_player_from_roster`: Manages player removal.
  - `public.get_tournament_team_roster`: Fetches detailed team compositions.

### 🧠 Business Logic (MediatR Handlers)
- **AddPlayerToRosterHandler**: 
  - Validates `JerseyNumber` uniqueness within the team for the specific tournament.
  - Ensures `PositionId` matches the tournament's `SportId` requirements.
  - Throws `ConflictException` (409) for rule violations.
- **RemovePlayerFromRosterHandler**: 
  - Prevents modifications to finished tournaments to maintain data integrity.
- **GetTeamRosterHandler**: 
  - Retrieves structured roster data with mapped player and position details.

### 🛡️ API & Security
- Created `RostersController` with the route `api/tournaments/{tournamentId}/rosters`.
- Implemented the following RESTful endpoints:
  - `POST /{teamId}` — Adds or updates a player in the roster (**201 Created**).
  - `GET /{teamId}` — Retrieves the team roster (**200 OK**).
  - `DELETE /{teamId}/{playerId}` — Removes a player from the roster (**204 No Content**).
- Secured operations using the `[Authorize(Policy = "TeamEditor")]` policy for granular access control.

## 🧪 Testing
Comprehensive integration tests have been implemented in `RostersControllerTests.cs`:
- ✅ `GetTeamRoster_ShouldReturnOk_WhenRosterExists`
- ✅ `AddPlayer_ShouldReturnCreated_WhenRequestIsValid`
- ✅ `AddPlayer_ShouldReturnConflict_WhenJerseyNumberIsTaken`
- ✅ `RemovePlayer_ShouldReturnNoContent_WhenPlayerExistsInRoster`

## 🔗 Related Issues
Closes #35

---
**Checklist:**
- [x] SQL scripts verified against PostgreSQL schema.
- [x] Error handling (404, 409, 400) aligned with project standards.
- [x] API routes and DTOs fully documented for OpenAPI/Swagger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roster management API: add, remove, and list team roster players with validation, conflict handling, and proper HTTP status codes.

* **Tests**
  * Extensive unit and integration tests for handlers, validators, repository, and controller flows including conflict and edge cases.

* **Chores**
  * Database schema and storage procedures updated to persist roster entries, record creation time, unique constraints, and supporting indexes.

* **Documentation**
  * Enhanced XML/docs comments for team and tournament types and API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->