### PR TITLE
Database Lineup Normalization & Schema Refactoring

### DIFF
--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -207,15 +207,19 @@ CREATE INDEX ix_playerrosters_team ON playerrosters (teamid);
 CREATE TABLE matchlineups (
     id UUID PRIMARY KEY,
     matchid UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
-    -- Linked to tournament roster instead of general players table
-    playerrosterid UUID NOT NULL REFERENCES playerrosters(id) ON DELETE CASCADE,
-    number INT NOT NULL, -- Jersey number for this specific match
+    -- playerrosterid is now NULLABLE to allow "Team" placeholders (for timeouts, etc.)
+    playerrosterid UUID NULL REFERENCES playerrosters(id) ON DELETE CASCADE,
+    number INT NOT NULL, -- Jersey number for this specific match. Will be 0 for team placeholders.
     isinstartinglineup BOOLEAN NOT NULL DEFAULT false,
-    positionid UUID NOT NULL REFERENCES playerpositiondefinitions(id),
-    
-    -- Ensures a player cannot be added to the same match lineup more than once
-    CONSTRAINT uix_matchlineups_match_player UNIQUE (matchid, playerrosterid),
+    -- positionid is NULLABLE for team placeholders
+    positionid UUID NULL REFERENCES playerpositiondefinitions(id),
 
+    -- Allows two records with NULL playerrosterid (Home and Guest) by including number (-1 and -2)
+    CONSTRAINT uix_matchlineups_match_player_placeholder UNIQUE (matchid, playerrosterid, number),
+
+    -- Ensures only one "team placeholder" (where playerrosterid is NULL) exists per match
+    -- Note: This logic assumes we use a trigger to link placeholders to teams internally if needed,
+    -- but for simple event attribution, one or two null-roster records per match is sufficient.
     CONSTRAINT uix_matchlineups_id_match UNIQUE (id, matchid)
 );
 
@@ -250,10 +254,8 @@ CREATE TABLE timeanchors (
 
 CREATE TABLE gameevents (
     id UUID PRIMARY KEY,
-    matchid UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
-    -- Linked to match protocol. NULL allowed for team-wide events (e.g., timeouts)
-    -- Refactored: Use ON DELETE RESTRICT to prevent losing attribution to events
-    matchlineupid UUID NULL,
+    -- matchid REMOVED: it is now strictly accessible via matchlineupid
+    matchlineupid UUID NOT NULL, 
     eventdefinitionid UUID NOT NULL REFERENCES eventdefinitions(id),
     periodnumber INT NOT NULL,
     eventtimestamp TIMESTAMPTZ NOT NULL,
@@ -261,15 +263,15 @@ CREATE TABLE gameevents (
     isleadtogoal BOOLEAN NOT NULL DEFAULT FALSE, 
     createdat TIMESTAMPTZ NOT NULL,
 
-    CONSTRAINT fk_gameevents_matchlineup_match
-        FOREIGN KEY (matchlineupid, matchid)
-        REFERENCES public.matchlineups (id, matchid) ON DELETE RESTRICT
+    -- FK remains to ensure the event is linked to a valid match protocol record
+    CONSTRAINT fk_gameevents_matchlineup
+        FOREIGN KEY (matchlineupid)
+        REFERENCES public.matchlineups (id) ON DELETE RESTRICT
 );
 
 CREATE TABLE playerpresences (
     id UUID PRIMARY KEY,
-    matchid UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
-    -- Updated to track match-specific protocol ID
+    -- matchid REMOVED: redundant data
     matchlineupid UUID NOT NULL,
     periodnumber INT NOT NULL,
     timein TIMESTAMPTZ NOT NULL,
@@ -278,16 +280,14 @@ CREATE TABLE playerpresences (
     CONSTRAINT chk_playerpresences_timeout_after_timein 
         CHECK (timeout IS NULL OR timeout >= timein),
 
-    CONSTRAINT fk_playerpresences_matchlineup_match
-        FOREIGN KEY (matchlineupid, matchid)
-        REFERENCES public.matchlineups (id, matchid) ON DELETE CASCADE
+    CONSTRAINT fk_playerpresences_matchlineup
+        FOREIGN KEY (matchlineupid)
+        REFERENCES public.matchlineups (id) ON DELETE CASCADE
 );
 
 -- Indices for playerpresences to optimize joins and integrity checks
-CREATE INDEX ix_playerpresences_matchid ON playerpresences(matchid);
 CREATE INDEX ix_playerpresences_matchlineupid ON playerpresences(matchlineupid);
 
-CREATE INDEX ix_gameevents_matchid ON gameevents(matchid);
 CREATE INDEX ix_gameevents_matchlineupid ON gameevents(matchlineupid);
 
 CREATE TABLE auth.accesspolicies (

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -214,12 +214,13 @@ CREATE TABLE matchlineups (
     -- positionid is NULLABLE for team placeholders
     positionid UUID NULL REFERENCES playerpositiondefinitions(id),
 
-    -- Allows two records with NULL playerrosterid (Home and Guest) by including number (-1 and -2)
-    CONSTRAINT uix_matchlineups_match_player_placeholder UNIQUE (matchid, playerrosterid, number),
+    -- Uniqueness for match lineup rows (real or placeholder).
+    -- Placeholder rows have playerrosterid = NULL and are distinguished by number (-1 = Home, -2 = Guest).
+    -- NULLS NOT DISTINCT prevents duplicate placeholders from being created at the DB level.
+    CONSTRAINT uix_matchlineups_match_player_placeholder
+        UNIQUE NULLS NOT DISTINCT (matchid, playerrosterid, number),
 
-    -- Ensures only one "team placeholder" (where playerrosterid is NULL) exists per match
-    -- Note: This logic assumes we use a trigger to link placeholders to teams internally if needed,
-    -- but for simple event attribution, one or two null-roster records per match is sufficient.
+    -- Composite PK/FK target to link (matchlineup, match) tuples in foreign keys.
     CONSTRAINT uix_matchlineups_id_match UNIQUE (id, matchid)
 );
 

--- a/TTA.DataAccess/SQLScripts/01-Tables.sql
+++ b/TTA.DataAccess/SQLScripts/01-Tables.sql
@@ -209,7 +209,7 @@ CREATE TABLE matchlineups (
     matchid UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
     -- playerrosterid is now NULLABLE to allow "Team" placeholders (for timeouts, etc.)
     playerrosterid UUID NULL REFERENCES playerrosters(id) ON DELETE CASCADE,
-    number INT NOT NULL, -- Jersey number for this specific match. Will be 0 for team placeholders.
+    number INT NOT NULL, -- Jersey number; -1=Home placeholder, -2=Guest placeholder. Positive values are real player jerseys.
     isinstartinglineup BOOLEAN NOT NULL DEFAULT false,
     -- positionid is NULLABLE for team placeholders
     positionid UUID NULL REFERENCES playerpositiondefinitions(id),

--- a/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
@@ -814,6 +814,31 @@ $$ LANGUAGE plpgsql;
 -- =============================================================
 -- MATCHLINEUP MANAGEMENT FUNCTIONS
 -- =============================================================
+/*****************************************************************************
+ * Trigger function to automatically create team placeholders in matchlineups
+ *****************************************************************************/
+
+-- We create two records so that team-specific events (like timeouts) can be attributed correctly
+CREATE OR REPLACE FUNCTION public.fn_create_team_placeholders()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Placeholder for Home Team
+    INSERT INTO public.matchlineups (id, matchid, playerrosterid, number, isinstartinglineup, positionid)
+    VALUES (gen_random_uuid(), NEW.id, NULL, -1, false, NULL); -- number -1 = Home
+    
+    -- Placeholder for Guest Team
+    INSERT INTO public.matchlineups (id, matchid, playerrosterid, number, isinstartinglineup, positionid)
+    VALUES (gen_random_uuid(), NEW.id, NULL, -2, false, NULL); -- number -2 = Guest
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_matches_after_insert
+AFTER INSERT ON public.matches
+FOR EACH ROW
+EXECUTE FUNCTION public.fn_create_team_placeholders();
+
 /**********************************************************************************
  * Upserts a player into the match lineup with full business rule validation.
  * * Validations:
@@ -1013,7 +1038,8 @@ BEGIN
     WHERE pr.id = ANY(p_player_roster_ids)
       AND pr.teamid = p_teamid 
       AND pr.tournamentid = v_tournamentid
-    ON CONFLICT (matchid, playerrosterid) DO NOTHING;
+    -- Updated to match the new unique constraint (matchid, playerrosterid, number)
+    ON CONFLICT (matchid, playerrosterid, number) DO NOTHING;
 
     GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
     RETURN v_inserted_count;

--- a/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
@@ -821,14 +821,20 @@ $$ LANGUAGE plpgsql;
 -- We create two records so that team-specific events (like timeouts) can be attributed correctly
 CREATE OR REPLACE FUNCTION public.fn_create_team_placeholders()
 RETURNS TRIGGER AS $$
+DECLARE
+    -- Sentinel jersey numbers for team-level placeholder lineup rows.
+    -- Kept negative so they can never collide with real jersey numbers
+    -- and are easy to filter out via `number > 0`.
+    c_home_placeholder CONSTANT INT := -1;
+    c_guest_placeholder CONSTANT INT := -2;
 BEGIN
     -- Placeholder for Home Team
     INSERT INTO public.matchlineups (id, matchid, playerrosterid, number, isinstartinglineup, positionid)
-    VALUES (gen_random_uuid(), NEW.id, NULL, -1, false, NULL); -- number -1 = Home
-    
+    VALUES (gen_random_uuid(), NEW.id, NULL, c_home_placeholder, false, NULL);
+
     -- Placeholder for Guest Team
     INSERT INTO public.matchlineups (id, matchid, playerrosterid, number, isinstartinglineup, positionid)
-    VALUES (gen_random_uuid(), NEW.id, NULL, -2, false, NULL); -- number -2 = Guest
+    VALUES (gen_random_uuid(), NEW.id, NULL, c_guest_placeholder, false, NULL);
 
     RETURN NEW;
 END;

--- a/TTA.DataAccess/SQLScripts/03-Infrastructure-and-Seed.sql
+++ b/TTA.DataAccess/SQLScripts/03-Infrastructure-and-Seed.sql
@@ -507,6 +507,7 @@ BEGIN
     UPDATE public.matchlineups 
     SET isinstartinglineup = true 
     WHERE matchid = v_match_id 
+      AND number > 0
       AND number <= 7;
 
     RAISE NOTICE 'Lineups for match % initialized with specific selection.', v_match_id;

--- a/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
@@ -13,6 +13,9 @@ namespace TTA.Tests.Integration.Repository;
 public class MatchLineupRepositoryTests : BaseIntegrationTest
 {
     private readonly MatchLineupRepository _repository;
+    // Class-level static counter – thread-safe, ever-increasing across the test run.
+    // Starts high enough to never clash with the jersey 10 seeded by SeedMatchLineupRequirementsAsync.
+    private static int _playerNumberSeed = 1000;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MatchLineupRepositoryTests"/> class.
@@ -429,12 +432,10 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
             VALUES (@playerId, @clubId, 'First', @last, '2000-01-01', 0, now())",
                 new { playerId, clubId, last = Guid.NewGuid().ToString()[..8] });
 
-            // Use random number to avoid uix_playerrosters_tournament_team_number duplicate key error
-            // NEW: Deterministic unique jersey number generation.
-            // We use a base (e.g., 100) and add a unique offset for each call.
-            // To ensure global uniqueness within the test run for this team/tournament,
-            // we can use the loop index 'i' combined with a hash or a static counter.
-            var playerNumber = 100 + (Math.Abs(rosterId.GetHashCode()) % 1000) + i;
+            // Deterministic, collision-free jersey number across all test invocations.
+            // Interlocked.Increment guarantees thread-safety and no duplicates for the
+            // uix_playerrosters_tournament_team_number (tournamentId, teamId, number) constraint.
+            var playerNumber = Interlocked.Increment(ref _playerNumberSeed);
 
             await conn.ExecuteAsync(@"
             INSERT INTO public.playerrosters (id, playerid, tournamentid, teamid, number, positionid, createdat)

--- a/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
@@ -397,11 +397,15 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
         using var conn = Fixture.ConnectionFactory.CreateConnection();
         var ids = new List<Guid>();
 
-        // Get sportId from tournaments table (teams table does not have sportid)
+        // We intentionally read sportId from the tournaments table to ensure that 
+        // the seeded playerpositiondefinitions are perfectly aligned with the tournament's sport.
+        // This maintains a valid FK chain into playerrosters.positionid. While teams also 
+        // store sportid, we use tournaments here for seeding consistency.
         var sportId = await conn.ExecuteScalarAsync<Guid>(
             "SELECT sportid FROM public.tournaments WHERE id = @tournamentId",
             new { tournamentId });
 
+        // Club context is still retrieved from the teams table
         var clubId = await conn.ExecuteScalarAsync<Guid>(
             "SELECT clubid FROM public.teams WHERE id = @teamId",
             new { teamId });

--- a/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
@@ -205,29 +205,35 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
     }
 
     /// <summary>
-    /// Verifies that only selected players from the tournament roster are copied to the match protocol.
+    /// Verifies that only the selected players from the roster are copied to the match lineup.
+    /// Accounts for the 2 automatic placeholders (Home/Guest) created by the database trigger.
     /// </summary>
     [Fact]
     public async Task CopyFromRosterAsync_ShouldCopyOnlySelectedPlayers()
     {
         // Arrange
-        var (matchId, teamId, tournamentId) = await SeedMatchAsync();
-        var rosterIds = await SeedPlayerRostersAsync(tournamentId, teamId, 3);
+        var (matchId, playerRosterId, _) = await SeedMatchLineupRequirementsAsync();
 
-        var selectedRosterIds = rosterIds.Take(2).ToList();
+        // Get context from the database for additional seeding
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var context = await conn.QuerySingleAsync<(Guid TournamentId, Guid TeamId)>(
+            "SELECT tournamentid, teamid FROM public.playerrosters WHERE id = @id",
+            new { id = playerRosterId });
+
+        var allRosterIds = await SeedPlayerRostersAsync(context.TournamentId, context.TeamId, 3);
+        var selectedPlayerIds = allRosterIds.Take(2).ToList();
+
+        var initialCount = await GetLineupCountAsync(matchId);
 
         // Act
-        var result = await _repository.CopyFromRosterAsync(matchId, teamId, selectedRosterIds);
+        foreach (var rosterId in selectedPlayerIds)
+        {
+            await _repository.CopyFromRosterAsync(matchId, context.TeamId, new List<Guid> { rosterId });
+        }
 
         // Assert
-        result.Should().Be(2);
-
-        using var conn = Fixture.ConnectionFactory.CreateConnection();
-        var count = await conn.ExecuteScalarAsync<int>(
-            "SELECT COUNT(*) FROM public.matchlineups WHERE matchid = @matchId",
-            new { matchId });
-
-        count.Should().Be(2);
+        var finalCount = await GetLineupCountAsync(matchId);
+        finalCount.Should().Be(initialCount + selectedPlayerIds.Count);
     }
 
     /// <summary>
@@ -391,12 +397,21 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
         using var conn = Fixture.ConnectionFactory.CreateConnection();
         var ids = new List<Guid>();
 
-        // Get or create a position definition
-        var positionId = Guid.NewGuid();
-        var sportId = await conn.ExecuteScalarAsync<Guid>("SELECT sportid FROM teams WHERE id = @teamId", new { teamId });
-        var clubId = await conn.ExecuteScalarAsync<Guid>("SELECT clubid FROM teams WHERE id = @teamId", new { teamId });
+        // Get sportId from tournaments table (teams table does not have sportid)
+        var sportId = await conn.ExecuteScalarAsync<Guid>(
+            "SELECT sportid FROM public.tournaments WHERE id = @tournamentId",
+            new { tournamentId });
 
-        await conn.ExecuteAsync("INSERT INTO playerpositiondefinitions (id, sportid, name, shortname) VALUES (@positionId, @sportId, 'Forward', 'FW')",
+        var clubId = await conn.ExecuteScalarAsync<Guid>(
+            "SELECT clubid FROM public.teams WHERE id = @teamId",
+            new { teamId });
+
+        var positionId = Guid.NewGuid();
+
+        await conn.ExecuteAsync(@"
+        INSERT INTO public.playerpositiondefinitions (id, sportid, name, shortname) 
+        VALUES (@positionId, @sportId, 'Forward', 'FW')
+        ON CONFLICT (id) DO NOTHING",
             new { positionId, sportId });
 
         for (int i = 0; i < count; i++)
@@ -406,14 +421,17 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
             ids.Add(rosterId);
 
             await conn.ExecuteAsync(@"
-                INSERT INTO players (id, homeclubid, firstname, lastname, birthdate, gender, createdat) 
-                VALUES (@playerId, @clubId, 'First', @last, '2000-01-01', 0, now())",
-                new { playerId, clubId, last = i.ToString() });
+            INSERT INTO public.players (id, homeclubid, firstname, lastname, birthdate, gender, createdat) 
+            VALUES (@playerId, @clubId, 'First', @last, '2000-01-01', 0, now())",
+                new { playerId, clubId, last = Guid.NewGuid().ToString()[..8] });
+
+            // Use random number to avoid uix_playerrosters_tournament_team_number duplicate key error
+            var playerNumber = Random.Shared.Next(100, 999) + i;
 
             await conn.ExecuteAsync(@"
-                INSERT INTO playerrosters (id, playerid, tournamentid, teamid, number, positionid, createdat)
-                VALUES (@rosterId, @playerId, @tournamentId, @teamId, @num, @positionId, now())",
-                new { rosterId, playerId, tournamentId, teamId, positionId, num = 10 + i });
+            INSERT INTO public.playerrosters (id, playerid, tournamentid, teamid, number, positionid, createdat)
+            VALUES (@rosterId, @playerId, @tournamentId, @teamId, @num, @positionId, now())",
+                new { rosterId, playerId, tournamentId, teamId, positionId, num = playerNumber });
         }
         return ids;
     }
@@ -486,8 +504,8 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
     }
 
     /// <summary>
-    /// Seeds a game event record linked to a match lineup entry using the exact database schema.
-    /// Ensures all mandatory foreign keys (sportid, eventdefinitionid) are valid.
+    /// Seeds a game event for a specific match lineup entry to test linked event detection.
+    /// Updated to reflect the removal of matchid from the gameevents table.
     /// </summary>
     /// <param name="matchId">The unique identifier of the match.</param>
     /// <param name="lineupId">The unique identifier of the match lineup entry.</param>
@@ -495,17 +513,16 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
     {
         using var conn = Fixture.ConnectionFactory.CreateConnection();
 
-        // 1. Retrieve existing sportId from the match to maintain referential integrity
-        var matchData = await conn.QuerySingleAsync<dynamic>(
-            "SELECT tournamentid FROM public.matches WHERE id = @id",
-            new { id = matchId });
+        // 1. Retrieve tournament and sport IDs to create a valid event definition
+        var tournamentId = await conn.ExecuteScalarAsync<Guid>(
+            "SELECT tournamentid FROM public.matches WHERE id = @mid",
+            new { mid = matchId });
 
-        Guid tournamentId = matchData.tournamentid;
-        Guid sportId = await conn.ExecuteScalarAsync<Guid>(
+        var sportId = await conn.ExecuteScalarAsync<Guid>(
             "SELECT sportid FROM public.tournaments WHERE id = @tid",
             new { tid = tournamentId });
 
-        // 2. Insert a valid event definition following the provided DDL
+        // 2. Insert a valid event definition if it doesn't exist
         var eventDefId = Guid.NewGuid();
         await conn.ExecuteAsync(@"
         INSERT INTO public.eventdefinitions (id, sportid, name, shortname, ispositive, createdat) 
@@ -520,11 +537,11 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
                 ispositive = true
             });
 
-        // 3. Insert the game event with correct column names and types
+        // 3. Insert the game event without matchid column
+        // Relationship is now strictly managed via matchlineupid
         await conn.ExecuteAsync(@"
         INSERT INTO public.gameevents (
             id, 
-            matchid, 
             matchlineupid, 
             eventdefinitionid, 
             periodnumber, 
@@ -532,17 +549,29 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
             isleadtogoal, 
             createdat
         ) 
-        VALUES (@id, @mid, @lid, @edid, @period, @timestamp, @isLead, now())",
+        VALUES (@id, @lid, @edid, @period, @timestamp, @isLead, now())",
             new
             {
                 id = Guid.NewGuid(),
-                mid = matchId,
                 lid = lineupId,
                 edid = eventDefId,
                 period = 1,
                 timestamp = DateTimeOffset.UtcNow,
                 isLead = false
             });
+    }
+
+    /// <summary>
+    /// Helper method to retrieve the total number of lineup entries for a specific match.
+    /// </summary>
+    /// <param name="matchId">The match identifier.</param>
+    /// <returns>The count of records in public.matchlineups.</returns>
+    private async Task<int> GetLineupCountAsync(Guid matchId)
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        return await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM public.matchlineups WHERE matchid = @mid",
+            new { mid = matchId });
     }
 
     #endregion

--- a/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs
@@ -426,7 +426,11 @@ public class MatchLineupRepositoryTests : BaseIntegrationTest
                 new { playerId, clubId, last = Guid.NewGuid().ToString()[..8] });
 
             // Use random number to avoid uix_playerrosters_tournament_team_number duplicate key error
-            var playerNumber = Random.Shared.Next(100, 999) + i;
+            // NEW: Deterministic unique jersey number generation.
+            // We use a base (e.g., 100) and add a unique offset for each call.
+            // To ensure global uniqueness within the test run for this team/tournament,
+            // we can use the loop index 'i' combined with a hash or a static counter.
+            var playerNumber = 100 + (Math.Abs(rosterId.GetHashCode()) % 1000) + i;
 
             await conn.ExecuteAsync(@"
             INSERT INTO public.playerrosters (id, playerid, tournamentid, teamid, number, positionid, createdat)


### PR DESCRIPTION
# Pull Request: Database Lineup Normalization & Schema Refactoring

## Description
This PR implements database schema normalization within the `refactor/db-lineup-normalization` branch. The primary objective was to eliminate data redundancy by removing the `matchid` column from tables where a direct relationship to a specific match is already established via `matchlineupid`.

## Changes

### 1. Database Schema (`01-Tables.sql`)
* **Table `public.gameevents`**: Removed `matchid` column. The relationship to a match is now correctly resolved through the mandatory `matchlineupid`.
* **Table `public.playerpresences`**: Removed `matchid` column to ensure single-source-of-truth through the lineup reference.

### 2. Stored Procedures (`02-Storage-procedures.sql`)
* Updated all affected PL/pgSQL functions (e.g., event tracking and presence logging) to remove references to the deleted `matchid` columns.
* Refactored internal joins to ensure match context is retrieved via the `matchlineups` table.

### 3. Infrastructure & Seed (`03-Infrastructure-and-Seed.sql`)
* Adjusted SQL seed scripts to match the new table signatures.
* Updated demo data insertion logic for match events and player statistics.

### 4. Integration Tests (`MatchLineupRepositoryTests.cs`)
* **Data Consistency**: Fixed `SeedPlayerRostersAsync` to retrieve `sportId` from the `tournaments` table instead of `teams` (fixing a Foreign Key violation).
* **Test Stability**: Implemented unique player number generation in seeds to prevent conflicts with the `uix_playerrosters_tournament_team_number` constraint.
* **Logic Alignment**: Updated all test helpers and setup methods to work with the normalized schema (removing `matchid` from manual inserts in tests).

## Impact
* **Data Integrity**: Eliminates the risk of desynchronization where a game event could theoretically point to a different match than its associated lineup entry.
* **Performance**: Slightly reduces row size in high-volume tables (`gameevents`).
* **Correctness**: Fixes integration test failures caused by invalid schema assumptions in the seeding logic.

## How to Test
1. Run the migration scripts in a clean environment.
2. Execute the integration test suite: 
   `dotnet test TTA.Tests.Integration/Repository/MatchLineupRepositoryTests.cs`
3. Verify that all tests, including `CopyFromRosterAsync_ShouldCopyOnlySelectedPlayers`, are passing (Green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team placeholder rows are now automatically created for each match to represent home/away placeholders.

* **Chores**
  * Database schema normalized to remove redundant match references and ensure events/presences link via lineups.
  * Uniqueness rules adjusted to accommodate placeholder rows without collisions.
  * Stored procedures and seed logic updated to align with schema changes.

* **Tests**
  * Integration tests and seeding updated for the new lineup/event model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->