### PR TITLE
Time Anchors Implementation (Match Timeline Control)

### DIFF
--- a/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/CreateGameEventHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/CreateGameEventHandlerTests.cs
@@ -180,7 +180,6 @@ public class CreateGameEventHandlerTests
             MatchLineupId: Guid.NewGuid(),
             EventDefinitionId: Guid.NewGuid(),
             PeriodNumber: 1,
-            EventTimestamp: DateTime.UtcNow,
             IsLeadToGoal: false);
     }
 }

--- a/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/GetGameEventByIdHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/GetGameEventByIdHandlerTests.cs
@@ -10,24 +10,24 @@ using TTA.DataAccess.Repository.Projections;
 namespace TTA.BusinessLogic.Tests.Features.GameEvents.Handlers;
 
 /// <summary>
-/// Unit tests for the <see cref="GetGameEventByIdQueryHandler"/> class.
+/// Unit tests for the <see cref="GetGameEventByIdHandler"/> class.
 /// Ensures correct mapping of repository results to DTOs and proper error handling.
 /// </summary>
-public class GetGameEventByIdQueryHandlerTests
+public class GetGameEventByIdHandlerTests
 {
     private readonly Mock<IGameEventRepository> _gameEventRepositoryMock;
-    private readonly Mock<ILogger<GetGameEventByIdQueryHandler>> _loggerMock;
-    private readonly GetGameEventByIdQueryHandler _handler;
+    private readonly Mock<ILogger<GetGameEventByIdHandler>> _loggerMock;
+    private readonly GetGameEventByIdHandler _handler;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GetGameEventByIdQueryHandlerTests"/> class.
+    /// Initializes a new instance of the <see cref="GetGameEventByIdHandlerTests"/> class.
     /// </summary>
-    public GetGameEventByIdQueryHandlerTests()
+    public GetGameEventByIdHandlerTests()
     {
         _gameEventRepositoryMock = new Mock<IGameEventRepository>();
-        _loggerMock = new Mock<ILogger<GetGameEventByIdQueryHandler>>();
+        _loggerMock = new Mock<ILogger<GetGameEventByIdHandler>>();
 
-        _handler = new GetGameEventByIdQueryHandler(
+        _handler = new GetGameEventByIdHandler(
             _gameEventRepositoryMock.Object,
             _loggerMock.Object);
     }

--- a/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/GetMatchEventsTimelineHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/GameEvents/Handlers/GetMatchEventsTimelineHandlerTests.cs
@@ -9,25 +9,25 @@ using TTA.DataAccess.Repository.Projections;
 namespace TTA.BusinessLogic.Tests.Features.GameEvents.Handlers;
 
 /// <summary>
-/// Unit tests for the <see cref="GetMatchEventsTimelineQueryHandler"/> class.
+/// Unit tests for the <see cref="GetMatchEventsTimelineHandler"/> class.
 /// Validates the mapping logic from raw repository data to a collection of DTOs.
 /// </summary>
-public class GetMatchEventsTimelineQueryHandlerTests
+public class GetMatchEventsTimelineHandlerTests
 {
     private readonly Mock<IGameEventRepository> _gameEventRepositoryMock;
-    private readonly Mock<ILogger<GetMatchEventsTimelineQueryHandler>> _loggerMock;
-    private readonly GetMatchEventsTimelineQueryHandler _handler;
+    private readonly Mock<ILogger<GetMatchEventsTimelineHandler>> _loggerMock;
+    private readonly GetMatchEventsTimelineHandler _handler;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="GetMatchEventsTimelineQueryHandlerTests"/> class.
+    /// Initializes a new instance of the <see cref="GetMatchEventsTimelineHandlerTests"/> class.
     /// Sets up mocks and the handler under test.
     /// </summary>
-    public GetMatchEventsTimelineQueryHandlerTests()
+    public GetMatchEventsTimelineHandlerTests()
     {
         _gameEventRepositoryMock = new Mock<IGameEventRepository>();
-        _loggerMock = new Mock<ILogger<GetMatchEventsTimelineQueryHandler>>();
+        _loggerMock = new Mock<ILogger<GetMatchEventsTimelineHandler>>();
 
-        _handler = new GetMatchEventsTimelineQueryHandler(
+        _handler = new GetMatchEventsTimelineHandler(
             _gameEventRepositoryMock.Object,
             _loggerMock.Object);
     }
@@ -238,7 +238,7 @@ public class GetMatchEventsTimelineQueryHandlerTests
     }
 
     /// <summary>
-    /// Helper method to create a dynamic raw event object using ExpandoObject.
+    /// Helper method to create a GameEventProjection object.
     /// Matches the property naming expected by the handler.
     /// </summary>
     /// <param name="id">The event ID.</param>
@@ -265,7 +265,7 @@ public class GetMatchEventsTimelineQueryHandlerTests
             IsPositive: true,
             PeriodNumber: period,
             EventTimestamp: eventTimestamp ?? DateTime.UtcNow,
-            // Rabbit's specific logic: 
+            // Specific logic: 
             // If the parameter is not provided (null), default to 20 minutes for legacy tests.
             // But if we use a specific sentinel or call it via named parameters, we handle it.
             NormalizedMatchTime: normalizedMatchTime ?? TimeSpan.FromMinutes(20),

--- a/TTA.BusinessLogic.Tests/Features/GameEvents/Validators/CreateGameEventRequestValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/GameEvents/Validators/CreateGameEventRequestValidatorTests.cs
@@ -31,7 +31,6 @@ public class CreateGameEventRequestValidatorTests
             MatchLineupId: Guid.NewGuid(),
             EventDefinitionId: Guid.NewGuid(),
             PeriodNumber: 1,
-            EventTimestamp: DateTime.UtcNow.AddMinutes(-5),
             IsLeadToGoal: false
         );
 
@@ -53,7 +52,6 @@ public class CreateGameEventRequestValidatorTests
             MatchLineupId: Guid.NewGuid(),
             EventDefinitionId: Guid.Empty,
             PeriodNumber: 1,
-            EventTimestamp: DateTime.UtcNow,
             IsLeadToGoal: false
         );
 
@@ -78,7 +76,6 @@ public class CreateGameEventRequestValidatorTests
             MatchLineupId: Guid.NewGuid(),
             EventDefinitionId: Guid.NewGuid(),
             PeriodNumber: invalidPeriod,
-            EventTimestamp: DateTime.UtcNow,
             IsLeadToGoal: false
         );
 
@@ -88,51 +85,5 @@ public class CreateGameEventRequestValidatorTests
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.PeriodNumber)
             .WithErrorMessage("Period number must be greater than zero.");
-    }
-
-    /// <summary>
-    /// Verifies that an error is returned when <see cref="CreateGameEventRequest.EventTimestamp"/> is empty (default).
-    /// </summary>
-    [Fact]
-    public void Validator_Should_HaveError_When_EventTimestampIsEmpty()
-    {
-        // Arrange
-        var request = new CreateGameEventRequest(
-            MatchLineupId: Guid.NewGuid(),
-            EventDefinitionId: Guid.NewGuid(),
-            PeriodNumber: 1,
-            EventTimestamp: default,
-            IsLeadToGoal: false
-        );
-
-        // Act
-        var result = _validator.TestValidate(request);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(x => x.EventTimestamp)
-            .WithErrorMessage("Event timestamp is required.");
-    }
-
-    /// <summary>
-    /// Verifies that an error is returned when <see cref="CreateGameEventRequest.EventTimestamp"/> is set in the future.
-    /// </summary>
-    [Fact]
-    public void Validator_Should_HaveError_When_EventTimestampIsInFuture()
-    {
-        // Arrange
-        var request = new CreateGameEventRequest(
-            MatchLineupId: Guid.NewGuid(),
-            EventDefinitionId: Guid.NewGuid(),
-            PeriodNumber: 1,
-            EventTimestamp: DateTime.UtcNow.AddHours(1),
-            IsLeadToGoal: false
-        );
-
-        // Act
-        var result = _validator.TestValidate(request);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(x => x.EventTimestamp)
-            .WithErrorMessage("Event timestamp cannot be in the future.");
     }
 }

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/CreateTimeAnchorHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/CreateTimeAnchorHandlerTests.cs
@@ -1,0 +1,231 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+using Match = TTA.DataAccess.Models.Match;
+
+namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="CreateTimeAnchorHandler"/> class.
+/// Ensures validation logic, state machine sequence rules, repository interaction, and exception mapping are correct.
+/// </summary>
+public class CreateTimeAnchorHandlerTests
+{
+    private readonly Mock<ITimeAnchorRepository> _timeAnchorRepositoryMock;
+    private readonly Mock<IMatchRepository> _matchRepositoryMock;
+    private readonly Mock<ILogger<CreateTimeAnchorHandler>> _loggerMock;
+    private readonly CreateTimeAnchorHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateTimeAnchorHandlerTests"/> class.
+    /// Sets up mocks and the handler under test.
+    /// </summary>
+    public CreateTimeAnchorHandlerTests()
+    {
+        _timeAnchorRepositoryMock = new Mock<ITimeAnchorRepository>();
+        _matchRepositoryMock = new Mock<IMatchRepository>();
+        _loggerMock = new Mock<ILogger<CreateTimeAnchorHandler>>();
+
+        _handler = new CreateTimeAnchorHandler(
+            _timeAnchorRepositoryMock.Object,
+            _matchRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler successfully creates a time anchor when the sequence is valid.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_CreateAnchor_When_SequenceIsValid()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.PeriodStart);
+        var match = new Match { Id = command.MatchId };
+        var createdAnchor = new TimeAnchor { Id = Guid.NewGuid() };
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(match);
+
+        // No existing anchors for this period
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.UpsertAsync(It.IsAny<TimeAnchor>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdAnchor);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(createdAnchor.Id);
+        _timeAnchorRepositoryMock.Verify(r => r.UpsertAsync(It.IsAny<TimeAnchor>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the handler throws a <see cref="NotFoundException"/> when the Match cannot be found.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_NotFoundException_When_MatchNotFound()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.PeriodStart);
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Match?)null);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"Match with ID {command.MatchId} was not found.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ConflictException"/> is thrown if we try to start a period that is already started.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_ConflictException_When_PeriodAlreadyStarted()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.PeriodStart);
+        var match = new Match { Id = command.MatchId };
+
+        var existingAnchors = new List<TimeAnchor>
+        {
+            new() { PeriodNumber = command.PeriodNumber, Type = TimeAnchorType.PeriodStart, Timestamp = DateTime.UtcNow }
+        };
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(match);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchors);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage($"Period {command.PeriodNumber} already started.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ConflictException"/> is thrown if we try to end a period before starting it.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_ConflictException_When_EndingUnstartedPeriod()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.PeriodEnd);
+        var match = new Match { Id = command.MatchId };
+
+        // Empty list -> PeriodStart is missing
+        var existingAnchors = new List<TimeAnchor>();
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(match);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchors);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage($"Cannot end period {command.PeriodNumber} before it starts.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ConflictException"/> is thrown if we try to start a stoppage when the match is already stopped.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_ConflictException_When_MatchAlreadyStopped()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.StoppageStart);
+        var match = new Match { Id = command.MatchId };
+
+        var existingAnchors = new List<TimeAnchor>
+        {
+            new() { PeriodNumber = command.PeriodNumber, Type = TimeAnchorType.PeriodStart, Timestamp = DateTime.UtcNow.AddMinutes(-10) },
+            new() { PeriodNumber = command.PeriodNumber, Type = TimeAnchorType.StoppageStart, Timestamp = DateTime.UtcNow }
+        };
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(match);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchors);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("Match is already stopped.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ConflictException"/> is thrown when a PostgreSQL custom business rule (P0001) is triggered.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_ConflictException_On_Postgres_BusinessRule_Violation()
+    {
+        // Arrange
+        var command = CreateCommand(TimeAnchorType.PeriodStart);
+        var match = new Match { Id = command.MatchId };
+        const string dbErrorMessage = "Custom DB validation error";
+
+        var pgException = new PostgresException(dbErrorMessage, "ERROR", "ERROR", "P0001");
+
+        _matchRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(match);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(command.MatchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TimeAnchor>());
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.UpsertAsync(It.IsAny<TimeAnchor>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(pgException);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    /// <summary>
+    /// Helper method to create a valid <see cref="CreateTimeAnchorCommand"/>.
+    /// </summary>
+    /// <param name="type">The type of anchor to create.</param>
+    /// <returns>A populated command instance.</returns>
+    private static CreateTimeAnchorCommand CreateCommand(TimeAnchorType type)
+    {
+        return new CreateTimeAnchorCommand(
+            MatchId: Guid.NewGuid(),
+            PeriodNumber: 1,
+            Type: type);
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandlerTests.cs
@@ -11,7 +11,7 @@ namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
 
 /// <summary>
 /// Unit tests for the <see cref="DeleteTimeAnchorHandler"/> class.
-/// Validates existence checks and the repository call flow during time anchor deletion.
+/// Validates existence checks, match scoping (IDOR prevention), and the repository call flow.
 /// </summary>
 public class DeleteTimeAnchorHandlerTests
 {
@@ -34,14 +34,17 @@ public class DeleteTimeAnchorHandlerTests
     }
 
     /// <summary>
-    /// Verifies that the handler successfully deletes a time anchor when it exists.
+    /// Verifies that the handler successfully deletes a time anchor when it exists 
+    /// and matches the specified match ID scope.
     /// </summary>
     [Fact]
     public async Task Handle_Should_ReturnTrue_When_AnchorIsDeletedSuccessfully()
     {
         // Arrange
-        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
-        var existingAnchor = new TimeAnchor { Id = command.Id };
+        var command = new DeleteTimeAnchorCommand(MatchId: Guid.NewGuid(), Id: Guid.NewGuid());
+
+        // FIX: Explicitly set MatchId to match the command's MatchId to pass validation
+        var existingAnchor = new TimeAnchor { Id = command.Id, MatchId = command.MatchId };
 
         _timeAnchorRepositoryMock
             .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
@@ -67,7 +70,7 @@ public class DeleteTimeAnchorHandlerTests
     public async Task Handle_Should_Throw_NotFoundException_When_AnchorDoesNotExist()
     {
         // Arrange
-        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
+        var command = new DeleteTimeAnchorCommand(MatchId: Guid.NewGuid(), Id: Guid.NewGuid());
 
         _timeAnchorRepositoryMock
             .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
@@ -77,8 +80,36 @@ public class DeleteTimeAnchorHandlerTests
         var act = async () => await _handler.Handle(command, CancellationToken.None);
 
         // Assert
+        // FIX: Update the expected exception message to match the new handler logic
         await act.Should().ThrowAsync<NotFoundException>()
-            .WithMessage($"Time anchor with ID {command.Id} was not found.");
+            .WithMessage($"Time anchor with ID {command.Id} was not found for the specified match.");
+
+        _timeAnchorRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that the handler throws a <see cref="NotFoundException"/> 
+    /// when attempting to delete an anchor that belongs to a different match (IDOR prevention).
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_NotFoundException_When_MatchIdDoesNotMatch()
+    {
+        // Arrange
+        var command = new DeleteTimeAnchorCommand(MatchId: Guid.NewGuid(), Id: Guid.NewGuid());
+
+        // Anchor exists, but belongs to a DIFFERENT match
+        var existingAnchor = new TimeAnchor { Id = command.Id, MatchId = Guid.NewGuid() };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchor);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"Time anchor with ID {command.Id} was not found for the specified match.");
 
         _timeAnchorRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -91,8 +122,10 @@ public class DeleteTimeAnchorHandlerTests
     public async Task Handle_Should_ReturnFalse_When_RepositoryDeletionFails()
     {
         // Arrange
-        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
-        var existingAnchor = new TimeAnchor { Id = command.Id };
+        var command = new DeleteTimeAnchorCommand(MatchId: Guid.NewGuid(), Id: Guid.NewGuid());
+
+        // FIX: Explicitly set MatchId to pass validation
+        var existingAnchor = new TimeAnchor { Id = command.Id, MatchId = command.MatchId };
 
         _timeAnchorRepositoryMock
             .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandlerTests.cs
@@ -1,0 +1,112 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="DeleteTimeAnchorHandler"/> class.
+/// Validates existence checks and the repository call flow during time anchor deletion.
+/// </summary>
+public class DeleteTimeAnchorHandlerTests
+{
+    private readonly Mock<ITimeAnchorRepository> _timeAnchorRepositoryMock;
+    private readonly Mock<ILogger<DeleteTimeAnchorHandler>> _loggerMock;
+    private readonly DeleteTimeAnchorHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteTimeAnchorHandlerTests"/> class.
+    /// Sets up mocks and the handler under test.
+    /// </summary>
+    public DeleteTimeAnchorHandlerTests()
+    {
+        _timeAnchorRepositoryMock = new Mock<ITimeAnchorRepository>();
+        _loggerMock = new Mock<ILogger<DeleteTimeAnchorHandler>>();
+
+        _handler = new DeleteTimeAnchorHandler(
+            _timeAnchorRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler successfully deletes a time anchor when it exists.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnTrue_When_AnchorIsDeletedSuccessfully()
+    {
+        // Arrange
+        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
+        var existingAnchor = new TimeAnchor { Id = command.Id };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchor);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.DeleteAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        _timeAnchorRepositoryMock.Verify(r => r.DeleteAsync(command.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the handler throws a <see cref="NotFoundException"/> 
+    /// when attempting to delete a non-existent time anchor.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_NotFoundException_When_AnchorDoesNotExist()
+    {
+        // Arrange
+        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TimeAnchor?)null);
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"Time anchor with ID {command.Id} was not found.");
+
+        _timeAnchorRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns false if the repository fails to delete 
+    /// an existing anchor (e.g., database constraint or zero rows affected).
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnFalse_When_RepositoryDeletionFails()
+    {
+        // Arrange
+        var command = new DeleteTimeAnchorCommand(Guid.NewGuid());
+        var existingAnchor = new TimeAnchor { Id = command.Id };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchor);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.DeleteAsync(command.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+        _timeAnchorRepositoryMock.Verify(r => r.DeleteAsync(command.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetMatchAnchorsHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetMatchAnchorsHandlerTests.cs
@@ -1,0 +1,165 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+using TTA.BusinessLogic.Features.TimeAnchors.Queries;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="GetMatchAnchorsHandler"/> class.
+/// Validates the mapping logic from raw repository data to a sorted collection of DTOs.
+/// </summary>
+public class GetMatchAnchorsHandlerTests
+{
+    private readonly Mock<ITimeAnchorRepository> _timeAnchorRepositoryMock;
+    private readonly Mock<ILogger<GetMatchAnchorsHandler>> _loggerMock;
+    private readonly GetMatchAnchorsHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetMatchAnchorsHandlerTests"/> class.
+    /// Sets up mocks and the handler under test.
+    /// </summary>
+    public GetMatchAnchorsHandlerTests()
+    {
+        _timeAnchorRepositoryMock = new Mock<ITimeAnchorRepository>();
+        _loggerMock = new Mock<ILogger<GetMatchAnchorsHandler>>();
+
+        _handler = new GetMatchAnchorsHandler(
+            _timeAnchorRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns a collection of <see cref="TimeAnchorResponse"/>
+    /// when time anchors exist for the given match.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnAnchors_When_AnchorsExist()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var query = new GetMatchAnchorsQuery(matchId);
+
+        var rawAnchors = new List<TimeAnchor>
+        {
+            CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.PeriodStart, DateTime.UtcNow.AddMinutes(-45)),
+            CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.PeriodEnd, DateTime.UtcNow)
+        };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawAnchors);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        var resultList = result.ToList();
+        resultList.Should().HaveCount(2);
+
+        resultList[0].Type.Should().Be(TimeAnchorType.PeriodStart);
+        resultList[0].PeriodNumber.Should().Be(1);
+        resultList[0].MatchId.Should().Be(matchId);
+
+        resultList[1].Type.Should().Be(TimeAnchorType.PeriodEnd);
+        resultList[1].PeriodNumber.Should().Be(1);
+        resultList[1].MatchId.Should().Be(matchId);
+
+        _timeAnchorRepositoryMock.Verify(r => r.GetMatchAnchorsAsync(matchId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns an empty collection when no time anchors are found for the match.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnEmptyCollection_When_NoAnchorsExist()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var query = new GetMatchAnchorsQuery(matchId);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+
+        _timeAnchorRepositoryMock.Verify(r => r.GetMatchAnchorsAsync(matchId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns time anchors in strict chronological order,
+    /// sorted primarily by their UTC Timestamp.
+    /// </summary>
+    [Fact]
+    public async Task Handle_ShouldReturnAnchorsInChronologicalOrder()
+    {
+        // Arrange
+        var matchId = Guid.NewGuid();
+        var query = new GetMatchAnchorsQuery(matchId);
+        var baseTimestamp = DateTime.UtcNow;
+
+        var anchor1 = CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.PeriodStart, baseTimestamp.AddMinutes(-20));
+        var anchor2 = CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.StoppageStart, baseTimestamp.AddMinutes(-15));
+        var anchor3 = CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.StoppageEnd, baseTimestamp.AddMinutes(-10));
+        var anchor4 = CreateRawAnchor(Guid.NewGuid(), matchId, 1, TimeAnchorType.PeriodEnd, baseTimestamp);
+
+        // Provide anchors out of order to ensure the handler sorts them properly
+        var rawAnchors = new List<TimeAnchor> { anchor3, anchor1, anchor4, anchor2 };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetMatchAnchorsAsync(matchId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawAnchors);
+
+        // Act
+        var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(4);
+
+        result[0].Type.Should().Be(TimeAnchorType.PeriodStart);
+        result[1].Type.Should().Be(TimeAnchorType.StoppageStart);
+        result[2].Type.Should().Be(TimeAnchorType.StoppageEnd);
+        result[3].Type.Should().Be(TimeAnchorType.PeriodEnd);
+
+        result[0].Timestamp.Should().BeBefore(result[1].Timestamp);
+        result[1].Timestamp.Should().BeBefore(result[2].Timestamp);
+        result[2].Timestamp.Should().BeBefore(result[3].Timestamp);
+    }
+
+    /// <summary>
+    /// Helper method to create a TimeAnchor model object with populated data.
+    /// </summary>
+    /// <param name="id">The unique identifier for the time anchor.</param>
+    /// <param name="matchId">The unique identifier of the associated match.</param>
+    /// <param name="period">The period number.</param>
+    /// <param name="type">The specific type of the time anchor.</param>
+    /// <param name="timestamp">The exact UTC timestamp when the anchor occurred.</param>
+    /// <returns>A populated TimeAnchor instance.</returns>
+    private static TimeAnchor CreateRawAnchor(
+        Guid id,
+        Guid matchId,
+        int period,
+        TimeAnchorType type,
+        DateTime timestamp)
+    {
+        return new TimeAnchor
+        {
+            Id = id,
+            MatchId = matchId,
+            PeriodNumber = period,
+            Type = type,
+            Timestamp = timestamp
+        };
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandlerTests.cs
@@ -1,0 +1,99 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+using TTA.BusinessLogic.Features.TimeAnchors.Queries;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="GetTimeAnchorByIdHandler"/> class.
+/// Ensures correct mapping of repository results to DTOs and proper error handling.
+/// </summary>
+public class GetTimeAnchorByIdHandlerTests
+{
+    private readonly Mock<ITimeAnchorRepository> _timeAnchorRepositoryMock;
+    private readonly Mock<ILogger<GetTimeAnchorByIdHandler>> _loggerMock;
+    private readonly GetTimeAnchorByIdHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetTimeAnchorByIdHandlerTests"/> class.
+    /// Sets up mocks and the handler under test.
+    /// </summary>
+    public GetTimeAnchorByIdHandlerTests()
+    {
+        _timeAnchorRepositoryMock = new Mock<ITimeAnchorRepository>();
+        _loggerMock = new Mock<ILogger<GetTimeAnchorByIdHandler>>();
+
+        _handler = new GetTimeAnchorByIdHandler(
+            _timeAnchorRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// Verifies that the handler returns a correctly populated response DTO
+    /// when the time anchor exists in the database.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnAnchorResponse_When_AnchorExists()
+    {
+        // Arrange
+        var anchorId = Guid.NewGuid();
+        var query = new GetTimeAnchorByIdQuery(anchorId);
+
+        var existingAnchor = new TimeAnchor
+        {
+            Id = anchorId,
+            MatchId = Guid.NewGuid(),
+            PeriodNumber = 2,
+            Type = TimeAnchorType.StoppageStart,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchor);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(anchorId);
+        result.MatchId.Should().Be(existingAnchor.MatchId);
+        result.PeriodNumber.Should().Be(existingAnchor.PeriodNumber);
+        result.Type.Should().Be(existingAnchor.Type);
+        result.Timestamp.Should().Be(existingAnchor.Timestamp);
+
+        _timeAnchorRepositoryMock.Verify(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="NotFoundException"/> is thrown 
+    /// when the requested time anchor does not exist.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_NotFoundException_When_AnchorDoesNotExist()
+    {
+        // Arrange
+        var anchorId = Guid.NewGuid();
+        var query = new GetTimeAnchorByIdQuery(anchorId);
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TimeAnchor?)null);
+
+        // Act
+        var act = async () => await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"Time anchor with ID {anchorId} was not found.");
+
+        _timeAnchorRepositoryMock.Verify(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandlerTests.cs
@@ -12,7 +12,7 @@ namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Handlers;
 
 /// <summary>
 /// Unit tests for the <see cref="GetTimeAnchorByIdHandler"/> class.
-/// Ensures correct mapping of repository results to DTOs and proper error handling.
+/// Ensures correct mapping of repository results to DTOs, scope validation, and proper error handling.
 /// </summary>
 public class GetTimeAnchorByIdHandlerTests
 {
@@ -36,19 +36,20 @@ public class GetTimeAnchorByIdHandlerTests
 
     /// <summary>
     /// Verifies that the handler returns a correctly populated response DTO
-    /// when the time anchor exists in the database.
+    /// when the time anchor exists and belongs to the specified match.
     /// </summary>
     [Fact]
-    public async Task Handle_Should_ReturnAnchorResponse_When_AnchorExists()
+    public async Task Handle_Should_ReturnAnchorResponse_When_AnchorExistsAndMatchIdIsCorrect()
     {
         // Arrange
         var anchorId = Guid.NewGuid();
-        var query = new GetTimeAnchorByIdQuery(anchorId);
+        var matchId = Guid.NewGuid();
+        var query = new GetTimeAnchorByIdQuery(matchId, anchorId);
 
         var existingAnchor = new TimeAnchor
         {
             Id = anchorId,
-            MatchId = Guid.NewGuid(),
+            MatchId = matchId,
             PeriodNumber = 2,
             Type = TimeAnchorType.StoppageStart,
             Timestamp = DateTime.UtcNow
@@ -81,7 +82,8 @@ public class GetTimeAnchorByIdHandlerTests
     {
         // Arrange
         var anchorId = Guid.NewGuid();
-        var query = new GetTimeAnchorByIdQuery(anchorId);
+        var matchId = Guid.NewGuid();
+        var query = new GetTimeAnchorByIdQuery(matchId, anchorId);
 
         _timeAnchorRepositoryMock
             .Setup(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()))
@@ -92,8 +94,42 @@ public class GetTimeAnchorByIdHandlerTests
 
         // Assert
         await act.Should().ThrowAsync<NotFoundException>()
-            .WithMessage($"Time anchor with ID {anchorId} was not found.");
+            .WithMessage($"Time anchor with ID {anchorId} was not found for the specified match.");
 
         _timeAnchorRepositoryMock.Verify(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="NotFoundException"/> is thrown 
+    /// when the anchor exists but belongs to a different match.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_Throw_NotFoundException_When_AnchorBelongsToDifferentMatch()
+    {
+        // Arrange
+        var anchorId = Guid.NewGuid();
+        var matchId = Guid.NewGuid();
+        var query = new GetTimeAnchorByIdQuery(matchId, anchorId);
+
+        // Setup existing anchor with a completely different MatchId
+        var existingAnchor = new TimeAnchor
+        {
+            Id = anchorId,
+            MatchId = Guid.NewGuid(),
+            PeriodNumber = 1,
+            Type = TimeAnchorType.PeriodStart,
+            Timestamp = DateTime.UtcNow
+        };
+
+        _timeAnchorRepositoryMock
+            .Setup(r => r.GetByIdAsync(anchorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingAnchor);
+
+        // Act
+        var act = async () => await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"Time anchor with ID {anchorId} was not found for the specified match.");
     }
 }

--- a/TTA.BusinessLogic.Tests/Features/TimeAnchors/Validators/CreateTimeAnchorRequestValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/TimeAnchors/Validators/CreateTimeAnchorRequestValidatorTests.cs
@@ -1,0 +1,85 @@
+﻿using FluentValidation.TestHelper;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+using TTA.BusinessLogic.Features.TimeAnchors.Validators;
+using TTA.DataAccess.Enums;
+
+namespace TTA.BusinessLogic.Tests.Features.TimeAnchors.Validators;
+
+/// <summary>
+/// Unit tests for the <see cref="CreateTimeAnchorRequestValidator"/> class.
+/// Validates business rules for creating a new time anchor request.
+/// </summary>
+public class CreateTimeAnchorRequestValidatorTests
+{
+    private readonly CreateTimeAnchorRequestValidator _validator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateTimeAnchorRequestValidatorTests"/> class.
+    /// </summary>
+    public CreateTimeAnchorRequestValidatorTests()
+    {
+        _validator = new CreateTimeAnchorRequestValidator();
+    }
+
+    /// <summary>
+    /// Verifies that the validator does not return any errors for a valid request.
+    /// </summary>
+    [Fact]
+    public void Validator_Should_NotHaveErrors_When_RequestIsValid()
+    {
+        // Arrange
+        var request = new CreateTimeAnchorRequest(
+            PeriodNumber: 1,
+            Type: TimeAnchorType.PeriodStart
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    /// <summary>
+    /// Verifies that an error is returned when <see cref="CreateTimeAnchorRequest.PeriodNumber"/> is zero or negative.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validator_Should_HaveError_When_PeriodNumberIsInvalid(int invalidPeriod)
+    {
+        // Arrange
+        var request = new CreateTimeAnchorRequest(
+            PeriodNumber: invalidPeriod,
+            Type: TimeAnchorType.PeriodStart
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PeriodNumber)
+            .WithErrorMessage("Period number must be greater than zero.");
+    }
+
+    /// <summary>
+    /// Verifies that an error is returned when <see cref="CreateTimeAnchorRequest.Type"/> contains an invalid enum value.
+    /// </summary>
+    [Fact]
+    public void Validator_Should_HaveError_When_TypeIsInvalid()
+    {
+        // Arrange
+        // Casting an invalid integer to the enum to simulate a bad API payload
+        var request = new CreateTimeAnchorRequest(
+            PeriodNumber: 1,
+            Type: (TimeAnchorType)999
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Type)
+            .WithErrorMessage("Invalid time anchor type provided.");
+    }
+}

--- a/TTA.BusinessLogic/Features/GameEvents/Commands/CreateGameEventCommand.cs
+++ b/TTA.BusinessLogic/Features/GameEvents/Commands/CreateGameEventCommand.cs
@@ -11,14 +11,12 @@ namespace TTA.BusinessLogic.Features.GameEvents.Commands;
 /// <param name="MatchLineupId">The unique identifier of the match lineup.</param>
 /// <param name="EventDefinitionId">The identifier of the event type definition.</param>
 /// <param name="PeriodNumber">The match period when the event occurred.</param>
-/// <param name="EventTimestamp">The UTC timestamp of the event.</param>
 /// <param name="IsLeadToGoal">Indicates if the event was a direct lead to a goal.</param>
 public record CreateGameEventCommand(
     Guid MatchId,
     Guid MatchLineupId,
     Guid EventDefinitionId,
     int PeriodNumber,
-    DateTime EventTimestamp,
     bool IsLeadToGoal) : IRequest<Guid>;
 
 /// <summary>
@@ -37,7 +35,8 @@ public static class CreateGameEventCommandExtensions
         MatchLineupId = cmd.MatchLineupId,
         EventDefinitionId = cmd.EventDefinitionId,
         PeriodNumber = cmd.PeriodNumber,
-        EventTimestamp = cmd.EventTimestamp,
+        // Enforcing UTC consistency as per project standards
+        EventTimestamp = DateTime.UtcNow,
         IsLeadToGoal = cmd.IsLeadToGoal,
         CreatedAt = DateTime.UtcNow
     };

--- a/TTA.BusinessLogic/Features/GameEvents/DTOs/CreateGameEventRequest.cs
+++ b/TTA.BusinessLogic/Features/GameEvents/DTOs/CreateGameEventRequest.cs
@@ -8,13 +8,11 @@ namespace TTA.BusinessLogic.Features.GameEvents.DTOs;
 /// <param name="MatchLineupId">The match lineup identifier (nullable for team events).</param>
 /// <param name="EventDefinitionId">The event definition identifier.</param>
 /// <param name="PeriodNumber">The period number when the event occurred.</param>
-/// <param name="EventTimestamp">The absolute timestamp of the event (UTC).</param>
 /// <param name="IsLeadToGoal">Indicates whether this event leads to a goal.</param>
 public record CreateGameEventRequest(
     Guid MatchLineupId,
     Guid EventDefinitionId,
     int PeriodNumber,
-    DateTime EventTimestamp,
     bool IsLeadToGoal);
 
 /// <summary>
@@ -33,6 +31,5 @@ public static class CreateGameEventRequestExtensions
         MatchLineupId: request.MatchLineupId,
         EventDefinitionId: request.EventDefinitionId,
         PeriodNumber: request.PeriodNumber,
-        EventTimestamp: request.EventTimestamp,
         IsLeadToGoal: request.IsLeadToGoal);
 }

--- a/TTA.BusinessLogic/Features/GameEvents/Handlers/GetGameEventByIdHandler.cs
+++ b/TTA.BusinessLogic/Features/GameEvents/Handlers/GetGameEventByIdHandler.cs
@@ -12,13 +12,13 @@ namespace TTA.BusinessLogic.Features.GameEvents.Handlers;
 /// </summary>
 /// <param name="gameEventRepository">The repository for game event data operations.</param>
 /// <param name="logger">The logger instance for tracking execution flow.</param>
-public class GetGameEventByIdQueryHandler(
+public class GetGameEventByIdHandler(
     IGameEventRepository gameEventRepository,
-    ILogger<GetGameEventByIdQueryHandler> logger)
+    ILogger<GetGameEventByIdHandler> logger)
     : IRequestHandler<GetGameEventByIdQuery, GameEventResponse>
 {
     private readonly IGameEventRepository _gameEventRepository = gameEventRepository;
-    private readonly ILogger<GetGameEventByIdQueryHandler> _logger = logger;
+    private readonly ILogger<GetGameEventByIdHandler> _logger = logger;
 
     /// <summary>
     /// Retrieves a detailed event record by ID and maps it to the response DTO.

--- a/TTA.BusinessLogic/Features/GameEvents/Handlers/GetMatchEventsTimelineHandler.cs
+++ b/TTA.BusinessLogic/Features/GameEvents/Handlers/GetMatchEventsTimelineHandler.cs
@@ -11,13 +11,13 @@ namespace TTA.BusinessLogic.Features.GameEvents.Handlers;
 /// </summary>
 /// <param name="gameEventRepository">The repository for game event data operations.</param>
 /// <param name="logger">The logger instance for tracking execution flow.</param>
-public class GetMatchEventsTimelineQueryHandler(
+public class GetMatchEventsTimelineHandler(
     IGameEventRepository gameEventRepository,
-    ILogger<GetMatchEventsTimelineQueryHandler> logger)
+    ILogger<GetMatchEventsTimelineHandler> logger)
     : IRequestHandler<GetMatchEventsTimelineQuery, IEnumerable<GameEventResponse>>
 {
     private readonly IGameEventRepository _gameEventRepository = gameEventRepository;
-    private readonly ILogger<GetMatchEventsTimelineQueryHandler> _logger = logger;
+    private readonly ILogger<GetMatchEventsTimelineHandler> _logger = logger;
 
     /// <summary>
     /// Fetches raw event data from the repository and maps it to a chronological list of response DTOs.

--- a/TTA.BusinessLogic/Features/GameEvents/Validators/CreateGameEventRequestValidator.cs
+++ b/TTA.BusinessLogic/Features/GameEvents/Validators/CreateGameEventRequestValidator.cs
@@ -19,10 +19,6 @@ public class CreateGameEventRequestValidator : AbstractValidator<CreateGameEvent
         RuleFor(x => x.PeriodNumber)
             .GreaterThan(0).WithMessage("Period number must be greater than zero.");
 
-        RuleFor(x => x.EventTimestamp)
-            .NotEmpty().WithMessage("Event timestamp is required.")
-            .LessThanOrEqualTo(_ => DateTime.UtcNow).WithMessage("Event timestamp cannot be in the future.");
-
         // Optional: If MatchLineupId is provided, it should not be an empty Guid
         RuleFor(x => x.MatchLineupId)
             .NotEqual(Guid.Empty)

--- a/TTA.BusinessLogic/Features/TimeAnchors/Commands/CreateTimeAnchorCommand.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Commands/CreateTimeAnchorCommand.cs
@@ -1,0 +1,38 @@
+﻿using MediatR;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Commands;
+
+/// <summary>
+/// Command to create a new time anchor for a match timeline.
+/// The timestamp is generated automatically on the server side using UTC.
+/// </summary>
+/// <param name="MatchId">The unique identifier of the match.</param>
+/// <param name="PeriodNumber">The match period number (e.g., 1, 2, etc.).</param>
+/// <param name="Type">The type of the time anchor (e.g., PeriodStart, PeriodEnd).</param>
+public record CreateTimeAnchorCommand(
+    Guid MatchId,
+    int PeriodNumber,
+    TimeAnchorType Type) : IRequest<Guid>;
+
+/// <summary>
+/// Extensions for mapping CreateTimeAnchorCommand to domain models.
+/// </summary>
+public static class CreateTimeAnchorCommandExtensions
+{
+    /// <summary>
+    /// Maps the creation command to a TimeAnchor entity and sets the current UTC timestamp.
+    /// </summary>
+    /// <param name="cmd">The command instance.</param>
+    /// <returns>A new TimeAnchor entity with a server-generated UTC timestamp.</returns>
+    public static TimeAnchor ToModel(this CreateTimeAnchorCommand cmd) => new()
+    {
+        Id = Guid.NewGuid(),
+        MatchId = cmd.MatchId,
+        PeriodNumber = cmd.PeriodNumber,
+        Type = cmd.Type,
+        // Enforcing UTC consistency as per project standards
+        Timestamp = DateTime.UtcNow
+    };
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/Commands/DeleteTimeAnchorCommand.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Commands/DeleteTimeAnchorCommand.cs
@@ -5,5 +5,6 @@ namespace TTA.BusinessLogic.Features.TimeAnchors.Commands;
 /// <summary>
 /// Command to permanently remove a time anchor record from the match timeline.
 /// </summary>
+/// <param name="MatchId">The unique identifier of the associated match (used for authorization scope validation).</param>
 /// <param name="Id">The unique identifier of the time anchor to delete.</param>
-public record DeleteTimeAnchorCommand(Guid Id) : IRequest<bool>;
+public record DeleteTimeAnchorCommand(Guid MatchId, Guid Id) : IRequest<bool>;

--- a/TTA.BusinessLogic/Features/TimeAnchors/Commands/DeleteTimeAnchorCommand.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Commands/DeleteTimeAnchorCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Commands;
+
+/// <summary>
+/// Command to permanently remove a time anchor record from the match timeline.
+/// </summary>
+/// <param name="Id">The unique identifier of the time anchor to delete.</param>
+public record DeleteTimeAnchorCommand(Guid Id) : IRequest<bool>;

--- a/TTA.BusinessLogic/Features/TimeAnchors/DTOs/CreateTimeAnchorRequest.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/DTOs/CreateTimeAnchorRequest.cs
@@ -1,0 +1,30 @@
+﻿using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.DataAccess.Enums;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+
+/// <summary>
+/// Data transfer object for creating a new time anchor.
+/// </summary>
+/// <param name="PeriodNumber">The match period number (e.g., 1, 2, etc.).</param>
+/// <param name="Type">The type of the time anchor (e.g., PeriodStart, PeriodEnd).</param>
+public record CreateTimeAnchorRequest(
+    int PeriodNumber,
+    TimeAnchorType Type);
+
+/// <summary>
+/// Mapping extensions for <see cref="CreateTimeAnchorRequest"/>.
+/// </summary>
+public static class CreateTimeAnchorRequestExtensions
+{
+    /// <summary>
+    /// Converts a request DTO to a creation command including the match context.
+    /// </summary>
+    /// <param name="request">The request DTO.</param>
+    /// <param name="matchId">The unique identifier of the match from the route.</param>
+    /// <returns>A configured <see cref="CreateTimeAnchorCommand"/>.</returns>
+    public static CreateTimeAnchorCommand ToCommand(this CreateTimeAnchorRequest request, Guid matchId) => new(
+        MatchId: matchId,
+        PeriodNumber: request.PeriodNumber,
+        Type: request.Type);
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/DTOs/TimeAnchorResponse.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/DTOs/TimeAnchorResponse.cs
@@ -1,0 +1,18 @@
+﻿using TTA.DataAccess.Enums;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+
+/// <summary>
+/// Data transfer object representing a time anchor for API responses.
+/// </summary>
+/// <param name="Id">The unique identifier of the time anchor.</param>
+/// <param name="MatchId">The unique identifier of the associated match.</param>
+/// <param name="PeriodNumber">The match period number when the anchor was created.</param>
+/// <param name="Type">The specific type of the time anchor (e.g., PeriodStart).</param>
+/// <param name="Timestamp">The UTC date and time when the anchor occurred.</param>
+public record TimeAnchorResponse(
+    Guid Id,
+    Guid MatchId,
+    int PeriodNumber,
+    TimeAnchorType Type,
+    DateTime Timestamp);

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
@@ -72,33 +72,37 @@ public class CreateTimeAnchorHandler(
     /// </summary>
     private static void ValidateSequence(CreateTimeAnchorCommand request, List<TimeAnchor> existing)
     {
+        // Pre-compute states to reduce cognitive complexity
         var last = existing.LastOrDefault();
+        bool hasPeriodStarted = existing.Any(a => a.Type == TimeAnchorType.PeriodStart);
+        bool hasPeriodEnded = existing.Any(a => a.Type == TimeAnchorType.PeriodEnd);
+        bool isStoppageActive = last?.Type == TimeAnchorType.StoppageStart;
 
         switch (request.Type)
         {
             case TimeAnchorType.PeriodStart:
-                if (existing.Any(a => a.Type == TimeAnchorType.PeriodStart))
+                if (hasPeriodStarted)
                     throw new ConflictException($"Period {request.PeriodNumber} already started.");
                 break;
 
             case TimeAnchorType.PeriodEnd:
-                if (!existing.Any(a => a.Type == TimeAnchorType.PeriodStart))
+                if (!hasPeriodStarted)
                     throw new ConflictException($"Cannot end period {request.PeriodNumber} before it starts.");
-                if (existing.Any(a => a.Type == TimeAnchorType.PeriodEnd))
+                if (hasPeriodEnded)
                     throw new ConflictException($"Period {request.PeriodNumber} is already finished.");
-                if (last?.Type == TimeAnchorType.StoppageStart)
+                if (isStoppageActive)
                     throw new ConflictException("Cannot end period: a stoppage is currently active.");
                 break;
 
             case TimeAnchorType.StoppageStart:
-                if (!existing.Any(a => a.Type == TimeAnchorType.PeriodStart) || existing.Any(a => a.Type == TimeAnchorType.PeriodEnd))
+                if (!hasPeriodStarted || hasPeriodEnded)
                     throw new ConflictException("Stoppage can only occur during an active period.");
-                if (last?.Type == TimeAnchorType.StoppageStart)
+                if (isStoppageActive)
                     throw new ConflictException("Match is already stopped.");
                 break;
 
             case TimeAnchorType.StoppageEnd:
-                if (last?.Type != TimeAnchorType.StoppageStart)
+                if (!isStoppageActive)
                     throw new ConflictException("Cannot end stoppage: Match was not stopped.");
                 break;
         }

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
@@ -4,6 +4,7 @@ using Npgsql;
 using TTA.BusinessLogic.Features.TimeAnchors.Commands;
 using TTA.Common.Exceptions;
 using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
 using TTA.DataAccess.Repository.Api;
 
 namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
@@ -69,7 +70,7 @@ public class CreateTimeAnchorHandler(
     /// <summary>
     /// Validates that the new anchor follows the logical rules of the match state.
     /// </summary>
-    private void ValidateSequence(CreateTimeAnchorCommand request, List<TTA.DataAccess.Models.TimeAnchor> existing)
+    private static void ValidateSequence(CreateTimeAnchorCommand request, List<TimeAnchor> existing)
     {
         var last = existing.LastOrDefault();
 

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
@@ -69,42 +69,59 @@ public class CreateTimeAnchorHandler(
 
     /// <summary>
     /// Validates that the new anchor follows the logical rules of the match state.
+    /// Routes the validation to specific helper methods based on the anchor type.
     /// </summary>
     private static void ValidateSequence(CreateTimeAnchorCommand request, List<TimeAnchor> existing)
     {
-        // Pre-compute states to reduce cognitive complexity
-        var last = existing.LastOrDefault();
+        // Pre-compute state variables to pass into pure validation helpers
         bool hasPeriodStarted = existing.Any(a => a.Type == TimeAnchorType.PeriodStart);
         bool hasPeriodEnded = existing.Any(a => a.Type == TimeAnchorType.PeriodEnd);
-        bool isStoppageActive = last?.Type == TimeAnchorType.StoppageStart;
+        bool isStoppageActive = existing.LastOrDefault()?.Type == TimeAnchorType.StoppageStart;
 
         switch (request.Type)
         {
             case TimeAnchorType.PeriodStart:
-                if (hasPeriodStarted)
-                    throw new ConflictException($"Period {request.PeriodNumber} already started.");
+                ValidatePeriodStart(request.PeriodNumber, hasPeriodStarted);
                 break;
-
             case TimeAnchorType.PeriodEnd:
-                if (!hasPeriodStarted)
-                    throw new ConflictException($"Cannot end period {request.PeriodNumber} before it starts.");
-                if (hasPeriodEnded)
-                    throw new ConflictException($"Period {request.PeriodNumber} is already finished.");
-                if (isStoppageActive)
-                    throw new ConflictException("Cannot end period: a stoppage is currently active.");
+                ValidatePeriodEnd(request.PeriodNumber, hasPeriodStarted, hasPeriodEnded, isStoppageActive);
                 break;
-
             case TimeAnchorType.StoppageStart:
-                if (!hasPeriodStarted || hasPeriodEnded)
-                    throw new ConflictException("Stoppage can only occur during an active period.");
-                if (isStoppageActive)
-                    throw new ConflictException("Match is already stopped.");
+                ValidateStoppageStart(hasPeriodStarted, hasPeriodEnded, isStoppageActive);
                 break;
-
             case TimeAnchorType.StoppageEnd:
-                if (!isStoppageActive)
-                    throw new ConflictException("Cannot end stoppage: Match was not stopped.");
+                ValidateStoppageEnd(isStoppageActive);
                 break;
         }
+    }
+
+    private static void ValidatePeriodStart(int periodNumber, bool hasPeriodStarted)
+    {
+        if (hasPeriodStarted)
+            throw new ConflictException($"Period {periodNumber} already started.");
+    }
+
+    private static void ValidatePeriodEnd(int periodNumber, bool hasPeriodStarted, bool hasPeriodEnded, bool isStoppageActive)
+    {
+        if (!hasPeriodStarted)
+            throw new ConflictException($"Cannot end period {periodNumber} before it starts.");
+        if (hasPeriodEnded)
+            throw new ConflictException($"Period {periodNumber} is already finished.");
+        if (isStoppageActive)
+            throw new ConflictException("Cannot end period: a stoppage is currently active.");
+    }
+
+    private static void ValidateStoppageStart(bool hasPeriodStarted, bool hasPeriodEnded, bool isStoppageActive)
+    {
+        if (!hasPeriodStarted || hasPeriodEnded)
+            throw new ConflictException("Stoppage can only occur during an active period.");
+        if (isStoppageActive)
+            throw new ConflictException("Match is already stopped.");
+    }
+
+    private static void ValidateStoppageEnd(bool isStoppageActive)
+    {
+        if (!isStoppageActive)
+            throw new ConflictException("Cannot end stoppage: Match was not stopped.");
     }
 }

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
@@ -86,6 +86,8 @@ public class CreateTimeAnchorHandler(
                     throw new ConflictException($"Cannot end period {request.PeriodNumber} before it starts.");
                 if (existing.Any(a => a.Type == TimeAnchorType.PeriodEnd))
                     throw new ConflictException($"Period {request.PeriodNumber} is already finished.");
+                if (last?.Type == TimeAnchorType.StoppageStart)
+                    throw new ConflictException("Cannot end period: a stoppage is currently active.");
                 break;
 
             case TimeAnchorType.StoppageStart:

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/CreateTimeAnchorHandler.cs
@@ -1,0 +1,103 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Handles the creation of a new time anchor with match validation.
+/// Relies on GlobalExceptionHandler for unhandled exceptions.
+/// </summary>
+/// <param name="timeAnchorRepository">The repository for time anchor data operations.</param>
+/// <param name="matchRepository">The repository for validating match existence.</param>
+/// <param name="logger">The logger instance for tracking execution flow.</param>
+public class CreateTimeAnchorHandler(
+    ITimeAnchorRepository timeAnchorRepository,
+    IMatchRepository matchRepository,
+    ILogger<CreateTimeAnchorHandler> logger) : IRequestHandler<CreateTimeAnchorCommand, Guid>
+{
+    private readonly ITimeAnchorRepository _timeAnchorRepository = timeAnchorRepository;
+    private readonly IMatchRepository _matchRepository = matchRepository;
+    private readonly ILogger<CreateTimeAnchorHandler> _logger = logger;
+
+    /// <summary>
+    /// Validates the match existence and persists the new time anchor record.
+    /// </summary>
+    /// <param name="request">The command containing anchor details and match context.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The unique identifier of the persisted time anchor.</returns>
+    /// <exception cref="NotFoundException">Thrown when the specified match does not exist.</exception>
+    /// <exception cref="ConflictException">Thrown when a database constraint or business rule is violated.</exception>
+    public async Task<Guid> Handle(CreateTimeAnchorCommand request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Attempting to create TimeAnchor {Type} for Match {MatchId}, Period {Period}.",
+            request.Type, request.MatchId, request.PeriodNumber);
+
+        // 1. Basic existence check
+        var match = await _matchRepository.GetByIdAsync(request.MatchId, cancellationToken);
+        if (match == null)
+        {
+            throw new NotFoundException($"Match with ID {request.MatchId} was not found.");
+        }
+
+        // 2. Logical sequence validation
+        var existingAnchors = await _timeAnchorRepository.GetMatchAnchorsAsync(request.MatchId, cancellationToken);
+        var periodAnchors = existingAnchors
+            .Where(a => a.PeriodNumber == request.PeriodNumber)
+            .OrderBy(a => a.Timestamp)
+            .ToList();
+
+        ValidateSequence(request, periodAnchors);
+
+        // 3. Persistence
+        var model = request.ToModel();
+        try
+        {
+            var result = await _timeAnchorRepository.UpsertAsync(model, cancellationToken);
+            return result.Id;
+        }
+        catch (PostgresException ex) when (ex.SqlState == "P0001")
+        {
+            throw new ConflictException(ex.MessageText, ex);
+        }
+    }
+
+    /// <summary>
+    /// Validates that the new anchor follows the logical rules of the match state.
+    /// </summary>
+    private void ValidateSequence(CreateTimeAnchorCommand request, List<TTA.DataAccess.Models.TimeAnchor> existing)
+    {
+        var last = existing.LastOrDefault();
+
+        switch (request.Type)
+        {
+            case TimeAnchorType.PeriodStart:
+                if (existing.Any(a => a.Type == TimeAnchorType.PeriodStart))
+                    throw new ConflictException($"Period {request.PeriodNumber} already started.");
+                break;
+
+            case TimeAnchorType.PeriodEnd:
+                if (!existing.Any(a => a.Type == TimeAnchorType.PeriodStart))
+                    throw new ConflictException($"Cannot end period {request.PeriodNumber} before it starts.");
+                if (existing.Any(a => a.Type == TimeAnchorType.PeriodEnd))
+                    throw new ConflictException($"Period {request.PeriodNumber} is already finished.");
+                break;
+
+            case TimeAnchorType.StoppageStart:
+                if (!existing.Any(a => a.Type == TimeAnchorType.PeriodStart) || existing.Any(a => a.Type == TimeAnchorType.PeriodEnd))
+                    throw new ConflictException("Stoppage can only occur during an active period.");
+                if (last?.Type == TimeAnchorType.StoppageStart)
+                    throw new ConflictException("Match is already stopped.");
+                break;
+
+            case TimeAnchorType.StoppageEnd:
+                if (last?.Type != TimeAnchorType.StoppageStart)
+                    throw new ConflictException("Cannot end stoppage: Match was not stopped.");
+                break;
+        }
+    }
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandler.cs
@@ -1,0 +1,56 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Handles the deletion of a specific time anchor.
+/// Ensures the record exists before invoking the repository deletion logic.
+/// </summary>
+/// <param name="timeAnchorRepository">The repository for time anchor data operations.</param>
+/// <param name="logger">The logger instance for tracking execution flow.</param>
+public class DeleteTimeAnchorHandler(
+    ITimeAnchorRepository timeAnchorRepository,
+    ILogger<DeleteTimeAnchorHandler> logger) : IRequestHandler<DeleteTimeAnchorCommand, bool>
+{
+    private readonly ITimeAnchorRepository _timeAnchorRepository = timeAnchorRepository;
+    private readonly ILogger<DeleteTimeAnchorHandler> _logger = logger;
+
+    /// <summary>
+    /// Processes the removal of a time anchor record.
+    /// </summary>
+    /// <param name="request">The command containing the anchor identifier.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation, returning true if the deletion was successful.</returns>
+    /// <exception cref="NotFoundException">Thrown when the time anchor with the specified ID does not exist.</exception>
+    public async Task<bool> Handle(DeleteTimeAnchorCommand request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Attempting to delete time anchor {Id}.", request.Id);
+
+        // 1. Verify existence before deletion to provide clear feedback
+        var existingAnchor = await _timeAnchorRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (existingAnchor == null)
+        {
+            _logger.LogWarning("Deletion failed: Time anchor {Id} not found.", request.Id);
+            throw new NotFoundException($"Time anchor with ID {request.Id} was not found.");
+        }
+
+        // 2. Perform deletion via repository using the dedicated storage function
+        var isDeleted = await _timeAnchorRepository.DeleteAsync(request.Id, cancellationToken);
+
+        if (isDeleted)
+        {
+            _logger.LogInformation("Time anchor {Id} successfully deleted.", request.Id);
+        }
+        else
+        {
+            // This case handles unexpected database behavior where the record was found but not removed
+            _logger.LogError("Time anchor {Id} was found but the deletion operation failed in the database.", request.Id);
+        }
+
+        return isDeleted;
+    }
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/DeleteTimeAnchorHandler.cs
@@ -22,20 +22,21 @@ public class DeleteTimeAnchorHandler(
     /// <summary>
     /// Processes the removal of a time anchor record.
     /// </summary>
-    /// <param name="request">The command containing the anchor identifier.</param>
+    /// <param name="request">The command containing the anchor and match identifiers.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation, returning true if the deletion was successful.</returns>
-    /// <exception cref="NotFoundException">Thrown when the time anchor with the specified ID does not exist.</exception>
+    /// <exception cref="NotFoundException">Thrown when the time anchor does not exist or does not belong to the specified match.</exception>
     public async Task<bool> Handle(DeleteTimeAnchorCommand request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Attempting to delete time anchor {Id}.", request.Id);
+        _logger.LogInformation("Attempting to delete time anchor {Id} for match {MatchId}.", request.Id, request.MatchId);
 
-        // 1. Verify existence before deletion to provide clear feedback
+        // 1. Verify existence and match scope before deletion to prevent IDOR vulnerabilities
         var existingAnchor = await _timeAnchorRepository.GetByIdAsync(request.Id, cancellationToken);
-        if (existingAnchor == null)
+
+        if (existingAnchor == null || existingAnchor.MatchId != request.MatchId)
         {
-            _logger.LogWarning("Deletion failed: Time anchor {Id} not found.", request.Id);
-            throw new NotFoundException($"Time anchor with ID {request.Id} was not found.");
+            _logger.LogWarning("Deletion failed: Time anchor {Id} not found or does not belong to match {MatchId}.", request.Id, request.MatchId);
+            throw new NotFoundException($"Time anchor with ID {request.Id} was not found for the specified match.");
         }
 
         // 2. Perform deletion via repository using the dedicated storage function
@@ -47,7 +48,6 @@ public class DeleteTimeAnchorHandler(
         }
         else
         {
-            // This case handles unexpected database behavior where the record was found but not removed
             _logger.LogError("Time anchor {Id} was found but the deletion operation failed in the database.", request.Id);
         }
 

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetMatchAnchorsHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetMatchAnchorsHandler.cs
@@ -1,0 +1,51 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+using TTA.BusinessLogic.Features.TimeAnchors.Queries;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Handles the retrieval of all time anchors for a specific match.
+/// </summary>
+/// <param name="timeAnchorRepository">The repository for time anchor data operations.</param>
+/// <param name="logger">The logger instance for tracking execution flow.</param>
+public class GetMatchAnchorsHandler(
+    ITimeAnchorRepository timeAnchorRepository,
+    ILogger<GetMatchAnchorsHandler> logger)
+    : IRequestHandler<GetMatchAnchorsQuery, IEnumerable<TimeAnchorResponse>>
+{
+    private readonly ITimeAnchorRepository _timeAnchorRepository = timeAnchorRepository;
+    private readonly ILogger<GetMatchAnchorsHandler> _logger = logger;
+
+    /// <summary>
+    /// Fetches time anchors for a match and maps them to response DTOs.
+    /// Sorting is applied chronologically based on the UTC timestamp.
+    /// </summary>
+    /// <param name="request">The query containing the match identifier.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A collection of time anchor responses ordered by time.</returns>
+    public async Task<IEnumerable<TimeAnchorResponse>> Handle(GetMatchAnchorsQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Fetching time anchors for Match {MatchId}.", request.MatchId);
+
+        // Using the correct repository method as defined in ITimeAnchorRepository
+        var anchors = await _timeAnchorRepository.GetMatchAnchorsAsync(request.MatchId, cancellationToken);
+
+        // Sorting by Timestamp is sufficient as it represents the absolute timeline of the match
+        var response = anchors
+            .OrderBy(a => a.Timestamp)
+            .Select(a => new TimeAnchorResponse(
+                Id: a.Id,
+                MatchId: a.MatchId,
+                PeriodNumber: a.PeriodNumber,
+                Type: a.Type,
+                Timestamp: a.Timestamp
+            )).ToList();
+
+        _logger.LogInformation("Successfully retrieved {Count} time anchors for Match {MatchId}.", response.Count, request.MatchId);
+
+        return response;
+    }
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandler.cs
@@ -1,0 +1,56 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+using TTA.BusinessLogic.Features.TimeAnchors.Queries;
+using TTA.Common.Exceptions;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
+
+/// <summary>
+/// Handles the retrieval of a single time anchor by its identifier.
+/// </summary>
+/// <param name="timeAnchorRepository">The repository for time anchor data operations.</param>
+/// <param name="logger">The logger instance for tracking execution flow.</param>
+public class GetTimeAnchorByIdHandler(
+    ITimeAnchorRepository timeAnchorRepository,
+    ILogger<GetTimeAnchorByIdHandler> logger)
+    : IRequestHandler<GetTimeAnchorByIdQuery, TimeAnchorResponse>
+{
+    private readonly ITimeAnchorRepository _timeAnchorRepository = timeAnchorRepository;
+    private readonly ILogger<GetTimeAnchorByIdHandler> _logger = logger;
+
+    /// <summary>
+    /// Fetches a time anchor record by ID and maps it to the response DTO.
+    /// </summary>
+    /// <param name="request">The query containing the anchor identifier.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation, containing the time anchor response.</returns>
+    /// <exception cref="NotFoundException">Thrown when the time anchor with the specified ID does not exist.</exception>
+    public async Task<TimeAnchorResponse> Handle(GetTimeAnchorByIdQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Fetching details for TimeAnchor {Id}.", request.Id);
+
+        // Accessing the repository to find the anchor by its unique identifier
+        var anchor = await _timeAnchorRepository.GetByIdAsync(request.Id, cancellationToken);
+
+        if (anchor == null)
+        {
+            _logger.LogWarning("Time anchor retrieval failed: Anchor {Id} not found.", request.Id);
+            throw new NotFoundException($"Time anchor with ID {request.Id} was not found.");
+        }
+
+        // Mapping the domain model to the response DTO
+        var response = new TimeAnchorResponse(
+            Id: anchor.Id,
+            MatchId: anchor.MatchId,
+            PeriodNumber: anchor.PeriodNumber,
+            Type: anchor.Type,
+            Timestamp: anchor.Timestamp
+        );
+
+        _logger.LogInformation("Successfully retrieved details for TimeAnchor {Id}.", request.Id);
+
+        return response;
+    }
+}

--- a/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandler.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Handlers/GetTimeAnchorByIdHandler.cs
@@ -8,7 +8,7 @@ using TTA.DataAccess.Repository.Api;
 namespace TTA.BusinessLogic.Features.TimeAnchors.Handlers;
 
 /// <summary>
-/// Handles the retrieval of a single time anchor by its identifier.
+/// Handles the retrieval of a single time anchor by its identifier and validates its match scope.
 /// </summary>
 /// <param name="timeAnchorRepository">The repository for time anchor data operations.</param>
 /// <param name="logger">The logger instance for tracking execution flow.</param>
@@ -21,23 +21,24 @@ public class GetTimeAnchorByIdHandler(
     private readonly ILogger<GetTimeAnchorByIdHandler> _logger = logger;
 
     /// <summary>
-    /// Fetches a time anchor record by ID and maps it to the response DTO.
+    /// Fetches a time anchor record by ID, verifies its match scope, and maps it to the response DTO.
     /// </summary>
-    /// <param name="request">The query containing the anchor identifier.</param>
+    /// <param name="request">The query containing the anchor and match identifiers.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation, containing the time anchor response.</returns>
-    /// <exception cref="NotFoundException">Thrown when the time anchor with the specified ID does not exist.</exception>
+    /// <exception cref="NotFoundException">Thrown when the time anchor does not exist or does not belong to the match.</exception>
     public async Task<TimeAnchorResponse> Handle(GetTimeAnchorByIdQuery request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Fetching details for TimeAnchor {Id}.", request.Id);
+        _logger.LogInformation("Fetching details for TimeAnchor {Id} in Match {MatchId}.", request.Id, request.MatchId);
 
         // Accessing the repository to find the anchor by its unique identifier
         var anchor = await _timeAnchorRepository.GetByIdAsync(request.Id, cancellationToken);
 
-        if (anchor == null)
+        // Verify existence and ensure the anchor belongs to the requested match
+        if (anchor == null || anchor.MatchId != request.MatchId)
         {
-            _logger.LogWarning("Time anchor retrieval failed: Anchor {Id} not found.", request.Id);
-            throw new NotFoundException($"Time anchor with ID {request.Id} was not found.");
+            _logger.LogWarning("Time anchor retrieval failed: Anchor {Id} not found or does not belong to match {MatchId}.", request.Id, request.MatchId);
+            throw new NotFoundException($"Time anchor with ID {request.Id} was not found for the specified match.");
         }
 
         // Mapping the domain model to the response DTO

--- a/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetMatchAnchorsQuery.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetMatchAnchorsQuery.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Queries;
+
+/// <summary>
+/// Query to retrieve all time anchors associated with a specific match.
+/// </summary>
+/// <param name="MatchId">The unique identifier of the match.</param>
+public record GetMatchAnchorsQuery(Guid MatchId) : IRequest<IEnumerable<TimeAnchorResponse>>;

--- a/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetTimeAnchorByIdQuery.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetTimeAnchorByIdQuery.cs
@@ -4,7 +4,8 @@ using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
 namespace TTA.BusinessLogic.Features.TimeAnchors.Queries;
 
 /// <summary>
-/// Query to retrieve detailed information about a specific time anchor by its ID.
+/// Query to retrieve detailed information about a specific time anchor, scoped by match.
 /// </summary>
+/// <param name="MatchId">The unique identifier of the match (used for scope validation).</param>
 /// <param name="Id">The unique identifier of the time anchor.</param>
-public record GetTimeAnchorByIdQuery(Guid Id) : IRequest<TimeAnchorResponse>;
+public record GetTimeAnchorByIdQuery(Guid MatchId, Guid Id) : IRequest<TimeAnchorResponse>;

--- a/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetTimeAnchorByIdQuery.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Queries/GetTimeAnchorByIdQuery.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Queries;
+
+/// <summary>
+/// Query to retrieve detailed information about a specific time anchor by its ID.
+/// </summary>
+/// <param name="Id">The unique identifier of the time anchor.</param>
+public record GetTimeAnchorByIdQuery(Guid Id) : IRequest<TimeAnchorResponse>;

--- a/TTA.BusinessLogic/Features/TimeAnchors/Validators/CreateTimeAnchorRequestValidator.cs
+++ b/TTA.BusinessLogic/Features/TimeAnchors/Validators/CreateTimeAnchorRequestValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+
+namespace TTA.BusinessLogic.Features.TimeAnchors.Validators;
+
+/// <summary>
+/// Validator for the <see cref="CreateTimeAnchorRequest"/> record.
+/// </summary>
+public class CreateTimeAnchorRequestValidator : AbstractValidator<CreateTimeAnchorRequest>
+{
+    /// <summary>
+    /// Initializes validation rules for <see cref="CreateTimeAnchorRequest"/>.
+    /// </summary>
+    public CreateTimeAnchorRequestValidator()
+    {
+        RuleFor(x => x.PeriodNumber)
+            .GreaterThan(0)
+            .WithMessage("Period number must be greater than zero.");
+
+        RuleFor(x => x.Type)
+            .IsInEnum()
+            .WithMessage("Invalid time anchor type provided.");
+    }
+}

--- a/TTA.BusinessLogic/Services/AccessService.cs
+++ b/TTA.BusinessLogic/Services/AccessService.cs
@@ -13,7 +13,7 @@ public class AccessService(IAccessRepository accessRepository) : IAccessService
         AppRole requiredRole,
         TargetScope targetType,
         Guid? targetId = null,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         // 1. Fetch the effective role from the DataAccess layer.
         // The repository now returns AppRole? directly, so we don't need string parsing.
@@ -21,7 +21,7 @@ public class AccessService(IAccessRepository accessRepository) : IAccessService
             userId,
             targetType,
             targetId,
-            ct);
+            cancellationToken);
 
         // 2. If no role is found in the database, access is denied by default.
         if (userRole == null)

--- a/TTA.BusinessLogic/Services/Api/IAccessService.cs
+++ b/TTA.BusinessLogic/Services/Api/IAccessService.cs
@@ -11,11 +11,12 @@ public interface IAccessService
     /// <param name="requiredRole">Minimum role required for the operation.</param>
     /// <param name="targetType">The scope of access (Global, Club, or Team).</param>
     /// <param name="targetId">Specific ID of the resource (null for Global scope).</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>True if access is granted; otherwise, false.</returns>
     Task<bool> HasAccessAsync(
         string userId,
         AppRole requiredRole,
         TargetScope targetType,
         Guid? targetId = null,
-        CancellationToken ct = default);
+        CancellationToken cancellationToken = default);
 }

--- a/TTA.DataAccess/Models/TimeAnchor.cs
+++ b/TTA.DataAccess/Models/TimeAnchor.cs
@@ -3,11 +3,36 @@ using TTA.DataAccess.Models.Base;
 
 namespace TTA.DataAccess.Models;
 
+/// <summary>
+/// Represents a critical time reference point (anchor) within a match period.
+/// These points are used to calculate "clean time" using piecewise-linear normalization.
+/// </summary>
 public class TimeAnchor : IKeyedEntity<Guid>
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for the time anchor.
+    /// </summary>
     public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the match this anchor belongs to.
+    /// </summary>
     public Guid MatchId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the period number (e.g., 1, 2, 3) during which the anchor was recorded.
+    /// </summary>
     public int PeriodNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the anchor.
+    /// 0: Period Start, 1: Period End, 2: Stoppage Start, 3: Stoppage End.
+    /// </summary>
     public TimeAnchorType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the real-world timestamp when the anchor occurred.
+    /// Stored and processed strictly in UTC.
+    /// </summary>
     public DateTime Timestamp { get; set; }
 }

--- a/TTA.DataAccess/Repository/Api/ITimeAnchorRepository.cs
+++ b/TTA.DataAccess/Repository/Api/ITimeAnchorRepository.cs
@@ -1,0 +1,43 @@
+﻿using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository.Api;
+
+/// <summary>
+/// Defines data access operations for the TimeAnchor entity.
+/// </summary>
+public interface ITimeAnchorRepository : IEntityRepositoryBase<Guid, TimeAnchor>
+{
+    /// <summary>
+    /// Persists a time anchor to the database using an upsert operation.
+    /// </summary>
+    /// <param name="entity">The time anchor entity to save.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The persisted time anchor entity.</returns>
+    Task<TimeAnchor> UpsertAsync(TimeAnchor entity, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a single time anchor by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the time anchor.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The time anchor entity if found; otherwise, null.</returns>
+    Task<TimeAnchor?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all time anchors associated with a specific match.
+    /// Results are returned in chronological order as defined by the storage function.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A collection of time anchor entities.</returns>
+    Task<IEnumerable<TimeAnchor>> GetMatchAnchorsAsync(Guid matchId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a time anchor from the database by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the anchor to delete.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation. Returns true if the operation was successful.</returns>
+    Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/TTA.DataAccess/Repository/SqlStatements.cs
+++ b/TTA.DataAccess/Repository/SqlStatements.cs
@@ -339,4 +339,43 @@ public static class SqlStatements
         public const string DeleteEvent =
             "SELECT public.delete_game_event(@p_id);";
     }
+
+    /// <summary>
+    /// SQL constants for Time Anchor related database operations.
+    /// Used for piecewise-linear time normalization in match timelines.
+    /// </summary>
+    public static class ForTimeAnchors
+    {
+        /// <summary>
+        /// Invokes the storage function to insert or update a time anchor.
+        /// Returns the full record from the public.timeanchors table.
+        /// </summary>
+        public const string UpsertTimeAnchor =
+            @"SELECT * FROM public.upsert_time_anchor(
+                @Id, 
+                @MatchId, 
+                @PeriodNumber, 
+                @Type, 
+                @Timestamp
+            );";
+
+        /// <summary>
+        /// Invokes the storage function to retrieve a specific time anchor by its unique identifier.
+        /// </summary>
+        public const string GetById =
+            "SELECT * FROM public.get_time_anchor_by_id(@p_id);";
+
+        /// <summary>
+        /// Invokes the storage function to retrieve all time anchors for a specific match.
+        /// Results are ordered chronologically by the database function.
+        /// </summary>
+        public const string GetMatchAnchors =
+            "SELECT * FROM public.get_match_anchors(@p_match_id);";
+
+        /// <summary>
+        /// Invokes the storage function to permanently remove a time anchor record.
+        /// </summary>
+        public const string DeleteAnchor =
+            "SELECT public.delete_time_anchor(@p_id);";
+    }
 }

--- a/TTA.DataAccess/Repository/TimeAnchorRepository.cs
+++ b/TTA.DataAccess/Repository/TimeAnchorRepository.cs
@@ -1,0 +1,62 @@
+﻿using Dapper;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository.Api;
+using TTA.DataAccess.Repository.Base;
+
+namespace TTA.DataAccess.Repository;
+
+/// <summary>
+/// Implements data access operations for time anchors using PostgreSQL storage functions.
+/// Supports piecewise-linear time normalization logic.
+/// </summary>
+/// <param name="connectionFactory">The factory used to create database connections.</param>
+public class TimeAnchorRepository(IDbConnectionFactory connectionFactory)
+    : EntityRepositoryBase<Guid, TimeAnchor>(connectionFactory), ITimeAnchorRepository
+{
+    /// <inheritdoc />
+    public async Task<TimeAnchor> UpsertAsync(TimeAnchor entity, CancellationToken cancellationToken = default)
+    {
+        // Executes the upsert function via base CreateOrUpdate.
+        // Parameters are mapped automatically from the entity properties to @Property names.
+        return await CreateOrUpdate(
+            entity,
+            SqlStatements.ForTimeAnchors.UpsertTimeAnchor,
+            null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<TimeAnchor?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        // Utilizing base GetById with the specific SQL constant for time anchors.
+        return await GetById(
+            id,
+            SqlStatements.ForTimeAnchors.GetById,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TimeAnchor>> GetMatchAnchorsAsync(Guid matchId, CancellationToken cancellationToken = default)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("p_match_id", matchId);
+
+        using var connection = await OpenConnectionAsync(cancellationToken);
+
+        // Retrieves all anchors for a match to build the time normalization timeline.
+        return await connection.QueryAsync<TimeAnchor>(new CommandDefinition(
+            SqlStatements.ForTimeAnchors.GetMatchAnchors,
+            parameters,
+            cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        // Utilizing base Delete method which handles the transaction and calls the storage function.
+        return await Delete(
+            id,
+            SqlStatements.ForTimeAnchors.DeleteAnchor,
+            cancellationToken);
+    }
+}

--- a/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
@@ -1287,3 +1287,87 @@ BEGIN
     RETURN FOUND;
 END;
 $$ LANGUAGE plpgsql;
+
+-- =============================================================
+-- TIME ANCHORS STORED FUNCTIONS
+-- =============================================================
+
+/**********************************************************************************
+ * Inserts or updates a time anchor record.
+ * If the provided ID exists, updates the record. Otherwise, inserts a new one.
+ * Returns the resulting row from the public.timeanchors table.
+ **********************************************************************************/
+CREATE OR REPLACE FUNCTION public.upsert_time_anchor(
+    p_id UUID,
+    p_match_id UUID,
+    p_period_number INT,
+    p_type INT,
+    p_timestamp TIMESTAMPTZ
+)
+RETURNS SETOF public.timeanchors AS $$
+BEGIN
+    RETURN QUERY
+    INSERT INTO public.timeanchors (
+        id,
+        matchid,
+        periodnumber,
+        type,
+        timestamp
+    )
+    VALUES (
+        p_id,
+        p_match_id,
+        p_period_number,
+        p_type,
+        p_timestamp
+    )
+    ON CONFLICT (id) DO UPDATE SET
+        matchid = EXCLUDED.matchid,
+        periodnumber = EXCLUDED.periodnumber,
+        type = EXCLUDED.type,
+        timestamp = EXCLUDED.timestamp
+    RETURNING *;
+END;$$ LANGUAGE plpgsql;
+
+/**********************************************************************************
+ * Retrieves a single time anchor record by its unique identifier.
+ **********************************************************************************/
+CREATE OR REPLACE FUNCTION public.get_time_anchor_by_id(
+    p_id UUID
+)
+RETURNS SETOF public.timeanchors AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM public.timeanchors
+    WHERE id = p_id;
+END;$$ LANGUAGE plpgsql;
+
+/**********************************************************************************
+ * Retrieves all time anchors associated with a specific match.
+ * Results are ordered chronologically by period and timestamp.
+ **********************************************************************************/
+CREATE OR REPLACE FUNCTION public.get_match_anchors(
+    p_match_id UUID
+)
+RETURNS SETOF public.timeanchors AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM public.timeanchors
+    WHERE matchid = p_match_id
+    ORDER BY periodnumber ASC, timestamp ASC;
+END;$$ LANGUAGE plpgsql;
+
+/**********************************************************************************
+ * Removes a specific time anchor record from the database.
+ * Returns TRUE if the record was successfully deleted, FALSE otherwise.
+ **********************************************************************************/
+CREATE OR REPLACE FUNCTION public.delete_time_anchor(
+    p_id UUID
+)
+RETURNS BOOLEAN AS $$
+BEGIN
+    DELETE FROM public.timeanchors
+    WHERE id = p_id;
+    
+    RETURN FOUND;
+END;$$ LANGUAGE plpgsql;

--- a/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
@@ -3,9 +3,13 @@ using FluentAssertions;
 using Npgsql;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using TTA.BusinessLogic.Features.GameEvents.DTOs;
 using TTA.BusinessLogic.Features.Matches.DTOs;
 using TTA.BusinessLogic.Features.MatchLineups.DTOs;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+using TTA.DataAccess.Enums;
 using TTA.Tests.Integration.Infrastructure;
 using Xunit.Abstractions;
 
@@ -473,7 +477,7 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         var eventDefId = await SeedEventDefinitionAsync(context.SportId, "Yellow Card", false);
         var lineupId = await SeedMatchLineupAsync(matchId, homeTeamId, context.CityId, context.TournamentId, context.SportId);
 
-        var request = new CreateGameEventRequest(lineupId, eventDefId, 1, DateTime.UtcNow.AddSeconds(-5), false);
+        var request = new CreateGameEventRequest(lineupId, eventDefId, 1, false);
 
         // Act
         var response = await Client.PostAsJsonAsync($"{BaseUrl}/{matchId}/events", request);
@@ -501,7 +505,7 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         var eventDefId = await SeedEventDefinitionAsync(context.SportId, "Timeout", true);
         var lineupId = await SeedMatchLineupAsync(matchId, homeTeamId, context.CityId, context.TournamentId, context.SportId);
 
-        var request = new CreateGameEventRequest(lineupId, eventDefId, 1, DateTime.UtcNow.AddSeconds(-5), false);
+        var request = new CreateGameEventRequest(lineupId, eventDefId, 1, false);
 
         // Act
         var response = await Client.PostAsJsonAsync($"{BaseUrl}/{matchId}/teams/{homeTeamId}/events", request);
@@ -596,6 +600,156 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    #endregion
+
+    #region Time Anchors Tests
+
+    /// <summary>
+    /// Verifies that retrieving match anchors returns an OK response with the list of anchors.
+    /// </summary>
+    [Fact]
+    public async Task GetMatchAnchors_ShouldReturnOk_WhenAnchorsExist()
+    {
+        // Arrange
+        var context = await SetupTournamentContextAsync(TestUserId);
+        var homeId = await SeedTeamAsync(context.CityId, context.SportId, "Home FC Anchors");
+        var guestId = await SeedTeamAsync(context.CityId, context.SportId, "Guest FC Anchors");
+
+        var matchId = Guid.NewGuid();
+        await SeedMatchAsync(matchId, context.TournamentId, homeId, guestId, "TA-01");
+
+        // Seed initial anchors for the match
+        await SeedTimeAnchorAsync(matchId, 1, (int)TimeAnchorType.PeriodStart);
+        await SeedTimeAnchorAsync(matchId, 1, (int)TimeAnchorType.PeriodEnd);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{matchId}/anchors");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Explicitly defining JSON options to handle string-to-enum conversion
+        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        jsonOptions.Converters.Add(new JsonStringEnumConverter());
+
+        var anchors = await response.Content.ReadFromJsonAsync<List<TimeAnchorResponse>>(jsonOptions);
+        anchors.Should().NotBeNull();
+        anchors!.Count.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    /// <summary>
+    /// Verifies that retrieving a specific time anchor by ID returns an OK response.
+    /// </summary>
+    [Fact]
+    public async Task GetTimeAnchorById_ShouldReturnOk_WhenExists()
+    {
+        // Arrange
+        var context = await SetupTournamentContextAsync(TestUserId);
+        var homeId = await SeedTeamAsync(context.CityId, context.SportId, "Home FC Anchor");
+        var guestId = await SeedTeamAsync(context.CityId, context.SportId, "Guest FC Anchor");
+
+        var matchId = Guid.NewGuid();
+        await SeedMatchAsync(matchId, context.TournamentId, homeId, guestId, "TA-02");
+
+        var anchorId = await SeedTimeAnchorAsync(matchId, 1, (int)TimeAnchorType.PeriodStart);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{matchId}/anchors/{anchorId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Explicitly defining JSON options to handle string-to-enum conversion
+        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        jsonOptions.Converters.Add(new JsonStringEnumConverter());
+
+        var anchor = await response.Content.ReadFromJsonAsync<TimeAnchorResponse>(jsonOptions);
+        anchor.Should().NotBeNull();
+        anchor!.Id.Should().Be(anchorId);
+        anchor.MatchId.Should().Be(matchId);
+    }
+
+    /// <summary>
+    /// Verifies that an authorized user (Tournament Owner) can successfully record a new time anchor.
+    /// </summary>
+    [Fact]
+    public async Task RecordTimeAnchor_ShouldReturnCreated_WhenUserIsAuthorized()
+    {
+        // Arrange
+        var context = await SetupTournamentContextAsync(TestUserId);
+        var homeId = await SeedTeamAsync(context.CityId, context.SportId, "Home FC RecAnchor");
+        var guestId = await SeedTeamAsync(context.CityId, context.SportId, "Guest FC RecAnchor");
+
+        var matchId = Guid.NewGuid();
+        await SeedMatchAsync(matchId, context.TournamentId, homeId, guestId, "TA-03");
+
+        var request = new CreateTimeAnchorRequest(1, TimeAnchorType.PeriodStart);
+
+        // Act
+        var response = await Client.PostAsJsonAsync($"{BaseUrl}/{matchId}/anchors", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var returnedId = await response.Content.ReadFromJsonAsync<Guid>();
+        returnedId.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that an authorized user (Tournament Owner) can delete an existing time anchor.
+    /// </summary>
+    [Fact]
+    public async Task DeleteTimeAnchor_ShouldReturnNoContent_WhenUserIsAuthorized()
+    {
+        // Arrange
+        var context = await SetupTournamentContextAsync(TestUserId);
+        var homeId = await SeedTeamAsync(context.CityId, context.SportId, "Home FC DelAnchor");
+        var guestId = await SeedTeamAsync(context.CityId, context.SportId, "Guest FC DelAnchor");
+
+        var matchId = Guid.NewGuid();
+        await SeedMatchAsync(matchId, context.TournamentId, homeId, guestId, "TA-04");
+
+        var anchorId = await SeedTimeAnchorAsync(matchId, 1, (int)TimeAnchorType.PeriodStart);
+
+        // Act
+        var response = await Client.DeleteAsync($"{BaseUrl}/{matchId}/anchors/{anchorId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    #endregion
+
+    #region Helpers for Time Anchors
+
+    /// <summary>
+    /// Seeds a time anchor record directly into the database for integration testing.
+    /// Bypasses the application layer to set up reliable initial state.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the associated match.</param>
+    /// <param name="periodNumber">The match period number.</param>
+    /// <param name="type">The integer representation of the time anchor type.</param>
+    /// <returns>The unique identifier of the seeded time anchor.</returns>
+    private async Task<Guid> SeedTimeAnchorAsync(Guid matchId, int periodNumber, int type)
+    {
+        using var conn = (NpgsqlConnection)Fixture.ConnectionFactory.CreateConnection();
+        await conn.OpenAsync();
+
+        var id = Guid.NewGuid();
+        const string sql = "INSERT INTO public.timeanchors (id, matchid, periodnumber, type, timestamp) VALUES (@id, @matchid, @period, @type, @ts)";
+
+        using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("matchid", matchId);
+        cmd.Parameters.AddWithValue("period", periodNumber);
+        cmd.Parameters.AddWithValue("type", type);
+        cmd.Parameters.AddWithValue("ts", DateTime.UtcNow);
+
+        await cmd.ExecuteNonQueryAsync();
+
+        return id;
     }
 
     #endregion

--- a/TTA.Tests.Integration/Repository/TimeAnchorRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/TimeAnchorRepositoryTests.cs
@@ -1,0 +1,217 @@
+﻿using Dapper;
+using FluentAssertions;
+using TTA.DataAccess.Enums;
+using TTA.DataAccess.Models;
+using TTA.DataAccess.Repository;
+using TTA.Tests.Integration.Infrastructure;
+
+namespace TTA.Tests.Integration.Repository;
+
+/// <summary>
+/// Integration tests for the <see cref="TimeAnchorRepository"/>.
+/// Validates data access logic and PostgreSQL storage function integration for match timelines.
+/// </summary>
+public class TimeAnchorRepositoryTests : BaseIntegrationTest
+{
+    private readonly TimeAnchorRepository _repository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeAnchorRepositoryTests"/> class.
+    /// </summary>
+    /// <param name="fixture">The shared database fixture.</param>
+    public TimeAnchorRepositoryTests(DatabaseFixture fixture) : base(fixture)
+    {
+        _repository = new TimeAnchorRepository(fixture.ConnectionFactory);
+    }
+
+    #region Integration Tests
+
+    /// <summary>
+    /// Verifies that <see cref="TimeAnchorRepository.UpsertAsync"/> correctly persists a new time anchor.
+    /// </summary>
+    [Fact]
+    public async Task UpsertAsync_ShouldPersistNewAnchor_WhenDataIsValid()
+    {
+        // Arrange
+        var matchId = await SeedTimeAnchorEnvironmentAsync();
+        var timeAnchor = CreateAnchorModel(matchId, 1, (TimeAnchorType)0); // 0 = PeriodStart
+
+        // Act
+        var result = await _repository.UpsertAsync(timeAnchor);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(timeAnchor.Id);
+        result.MatchId.Should().Be(matchId);
+
+        var persisted = await _repository.GetByIdAsync(timeAnchor.Id);
+        persisted.Should().NotBeNull();
+        persisted!.Timestamp.Should().BeCloseTo(timeAnchor.Timestamp, TimeSpan.FromMilliseconds(1));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="TimeAnchorRepository.GetByIdAsync"/> retrieves an existing time anchor.
+    /// </summary>
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnEntity_WhenExists()
+    {
+        // Arrange
+        var matchId = await SeedTimeAnchorEnvironmentAsync();
+        var timeAnchor = CreateAnchorModel(matchId, 1, (TimeAnchorType)0);
+        await _repository.UpsertAsync(timeAnchor);
+
+        // Act
+        var result = await _repository.GetByIdAsync(timeAnchor.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(timeAnchor.Id);
+        result.PeriodNumber.Should().Be(timeAnchor.PeriodNumber);
+        result.Type.Should().Be(timeAnchor.Type);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="TimeAnchorRepository.GetMatchAnchorsAsync"/> returns all anchors for a specific match.
+    /// </summary>
+    [Fact]
+    public async Task GetMatchAnchorsAsync_ShouldReturnTimeline_ForSpecificMatch()
+    {
+        // Arrange
+        var matchId = await SeedTimeAnchorEnvironmentAsync();
+
+        var anchor1 = CreateAnchorModel(matchId, 1, (TimeAnchorType)0); // PeriodStart
+        var anchor2 = CreateAnchorModel(matchId, 1, (TimeAnchorType)1); // PeriodEnd
+        // Ensure chronological difference
+        anchor2.Timestamp = anchor1.Timestamp.AddMinutes(45);
+
+        await _repository.UpsertAsync(anchor1);
+        await _repository.UpsertAsync(anchor2);
+
+        // Act
+        var timeline = await _repository.GetMatchAnchorsAsync(matchId);
+
+        // Assert
+        var anchors = timeline.ToList();
+        anchors.Count.Should().BeGreaterThanOrEqualTo(2);
+        anchors.Should().Contain(a => a.Id == anchor1.Id);
+        anchors.Should().Contain(a => a.Id == anchor2.Id);
+    }
+
+    /// <summary>
+    /// Verifies that a time anchor is successfully removed from the database.
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveAnchor_WhenExists()
+    {
+        // Arrange
+        var matchId = await SeedTimeAnchorEnvironmentAsync();
+        var newAnchor = CreateAnchorModel(matchId, 1, (TimeAnchorType)0);
+
+        // Ensure record exists before deletion
+        await _repository.UpsertAsync(newAnchor);
+
+        // Act
+        var isDeleted = await _repository.DeleteAsync(newAnchor.Id);
+        var deletedCheck = await _repository.GetByIdAsync(newAnchor.Id);
+
+        // Assert
+        isDeleted.Should().BeTrue("Repository must return true when the record is successfully deleted");
+        deletedCheck.Should().BeNull("The record should no longer exist in the database");
+    }
+
+    #endregion
+
+    #region Seed Helpers
+
+    /// <summary>
+    /// Seeds the environment for integration tests.
+    /// Creates the minimum required hierarchy up to a valid Match record.
+    /// </summary>
+    /// <returns>The unique identifier of the created match.</returns>
+    private async Task<Guid> SeedTimeAnchorEnvironmentAsync()
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+
+        // Geography
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.countries (name, code) 
+            SELECT 'Ukraine', 'UA' WHERE NOT EXISTS (SELECT 1 FROM public.countries WHERE name = 'Ukraine')");
+        var countryId = await conn.QuerySingleAsync<int>("SELECT id FROM public.countries WHERE name = 'Ukraine'");
+
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.regions (countryid, name) 
+            SELECT @cid, 'Dnipro Region' WHERE NOT EXISTS (SELECT 1 FROM public.regions WHERE name = 'Dnipro Region' AND countryid = @cid)",
+            new { cid = countryId });
+        var regionId = await conn.QuerySingleAsync<int>("SELECT id FROM public.regions WHERE name = 'Dnipro Region'");
+
+        var cityId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.cities (id, regionid, name) 
+            SELECT @id, @rid, 'Dnipro' WHERE NOT EXISTS (SELECT 1 FROM public.cities WHERE id = @id)",
+            new { id = cityId, rid = regionId });
+
+        // User
+        var userId = "auth0|integration-tester";
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.users (id, email, displayname, createdat) 
+            SELECT @id, 'test@tta.com', 'Tester', NOW() WHERE NOT EXISTS (SELECT 1 FROM public.users WHERE id = @id)",
+            new { id = userId });
+
+        // Sport & Config
+        var sportId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.sports (id, name) 
+            SELECT @id, 'Football' WHERE NOT EXISTS (SELECT 1 FROM public.sports WHERE id = @id)",
+            new { id = sportId });
+
+        var configId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.sportconfigurations (id, sportid, usescleantime, periodscount, perioddurationminutes, fieldsize, rosterlimit, lineuplimit) 
+            SELECT @id, @sid, false, 2, 45, '105x68', 25, 11 WHERE NOT EXISTS (SELECT 1 FROM public.sportconfigurations WHERE sportid = @sid)",
+            new { id = configId, sid = sportId });
+
+        // Transactional Data
+        var suffix = Guid.NewGuid().ToString("N").Substring(0, 6);
+
+        var clubId = Guid.NewGuid();
+        await conn.ExecuteAsync("INSERT INTO public.clubs (id, cityid, name, createdat) VALUES (@id, @cityid, @name, NOW())",
+            new { id = clubId, cityid = cityId, name = $"Club_{suffix}" });
+
+        var tournamentId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.tournaments (id, sportid, configurationid, cityid, ownerid, name, startdate, createdat) 
+            VALUES (@id, @sid, (SELECT id FROM public.sportconfigurations WHERE sportid = @sid LIMIT 1), @cityid, @oid, @name, NOW(), NOW())",
+            new { id = tournamentId, sid = sportId, cityid = cityId, oid = userId, name = $"Tournament_{suffix}" });
+
+        var teamId = Guid.NewGuid();
+        await conn.ExecuteAsync("INSERT INTO public.teams (id, clubid, sportid, name, gender, createdat) VALUES (@id, @cid, @sid, @name, 0, NOW())",
+            new { id = teamId, cid = clubId, sid = sportId, name = $"Team_{suffix}" });
+
+        var matchId = Guid.NewGuid();
+        // Inserting directly bypasses full procedural validation ensuring isolation and speed for repository tests
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.matches (id, tournamentid, hometeamid, guestteamid, scheduledat, createdat) 
+            VALUES (@id, @tid, @teamid, @teamid, NOW(), NOW())",
+            new { id = matchId, tid = tournamentId, teamid = teamId });
+
+        return matchId;
+    }
+
+    /// <summary>
+    /// Creates a standard <see cref="TimeAnchor"/> model for testing.
+    /// </summary>
+    private static TimeAnchor CreateAnchorModel(Guid matchId, int periodNumber, TimeAnchorType type)
+    {
+        return new TimeAnchor
+        {
+            Id = Guid.NewGuid(),
+            MatchId = matchId,
+            PeriodNumber = periodNumber,
+            Type = type,
+            // Uses UTC as strictly requested by project rules
+            Timestamp = DateTime.UtcNow
+        };
+    }
+
+    #endregion
+}

--- a/TTA.Tests.Integration/Repository/TimeAnchorRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/TimeAnchorRepositoryTests.cs
@@ -92,9 +92,11 @@ public class TimeAnchorRepositoryTests : BaseIntegrationTest
 
         // Assert
         var anchors = timeline.ToList();
-        anchors.Count.Should().BeGreaterThanOrEqualTo(2);
+        anchors.Should().OnlyContain(a => a.MatchId == matchId);
         anchors.Should().Contain(a => a.Id == anchor1.Id);
         anchors.Should().Contain(a => a.Id == anchor2.Id);
+        anchors.FindIndex(a => a.Id == anchor1.Id)
+            .Should().BeLessThan(anchors.FindIndex(a => a.Id == anchor2.Id));
     }
 
     /// <summary>

--- a/TTA.WebAPI/Controllers/GameEventsController.cs
+++ b/TTA.WebAPI/Controllers/GameEventsController.cs
@@ -44,7 +44,7 @@ public class GameEventsController(
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(GameEventResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetById(Guid id)
+    public async Task<IActionResult> GetById([FromRoute] Guid id)
     {
         _logger.LogInformation("Retrieving details for game event {Id}.", id);
         var result = await _mediator.Send(new GetGameEventByIdQuery(id));
@@ -71,7 +71,7 @@ public class GameEventsController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> Delete(Guid id)
+    public async Task<IActionResult> Delete([FromRoute] Guid id)
     {
         _logger.LogInformation("Attempting to delete game event {Id} by tournament owner.", id);
 

--- a/TTA.WebAPI/Controllers/MatchLineupsController.cs
+++ b/TTA.WebAPI/Controllers/MatchLineupsController.cs
@@ -75,7 +75,12 @@ public class MatchLineupsController(
 
         // 1. Validate the incoming request data
         var validationResult = await validator.ValidateAsync(request);
-        if (!validationResult.IsValid) return BadRequest(validationResult.Errors);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for updating match lineup entry {Id}: {Errors}", id, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+            ;
 
         // 2. Validate ownership of the entry to ensure the user has permission to update it
         var authResult = await ValidateEntryOwnership(id);

--- a/TTA.WebAPI/Controllers/MatchLineupsController.cs
+++ b/TTA.WebAPI/Controllers/MatchLineupsController.cs
@@ -80,7 +80,6 @@ public class MatchLineupsController(
             _logger.LogWarning("Validation failed for updating match lineup entry {Id}: {Errors}", id, validationResult.Errors);
             return BadRequest(validationResult.Errors);
         }
-            ;
 
         // 2. Validate ownership of the entry to ensure the user has permission to update it
         var authResult = await ValidateEntryOwnership(id);

--- a/TTA.WebAPI/Controllers/MatchesController.cs
+++ b/TTA.WebAPI/Controllers/MatchesController.cs
@@ -689,7 +689,8 @@ public class MatchesController(
         if (authResult != null) return authResult;
 
         // Note: The handler for DeleteTimeAnchorCommand handles existence check and throws NotFoundException if anchor is missing,
-        await _mediator.Send(new DeleteTimeAnchorCommand(id), cancellationToken);
+        // pass both matchId and id to the command
+        await _mediator.Send(new DeleteTimeAnchorCommand(matchId, id), cancellationToken);
 
         return NoContent();
     }

--- a/TTA.WebAPI/Controllers/MatchesController.cs
+++ b/TTA.WebAPI/Controllers/MatchesController.cs
@@ -615,7 +615,7 @@ public class MatchesController(
     public async Task<IActionResult> GetTimeAnchorById(Guid matchId, Guid id, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Retrieving time anchor {Id} for match {MatchId}.", id, matchId);
-        var anchor = await _mediator.Send(new GetTimeAnchorByIdQuery(id), cancellationToken);
+        var anchor = await _mediator.Send(new GetTimeAnchorByIdQuery(matchId, id), cancellationToken);
 
         return Ok(anchor);
     }

--- a/TTA.WebAPI/Controllers/MatchesController.cs
+++ b/TTA.WebAPI/Controllers/MatchesController.cs
@@ -9,7 +9,12 @@ using TTA.BusinessLogic.Features.Matches.DTOs;
 using TTA.BusinessLogic.Features.Matches.Queries;
 using TTA.BusinessLogic.Features.MatchLineups.DTOs;
 using TTA.BusinessLogic.Features.MatchLineups.Queries;
+using TTA.BusinessLogic.Features.TimeAnchors.Commands;
+using TTA.BusinessLogic.Features.TimeAnchors.DTOs;
+using TTA.BusinessLogic.Features.TimeAnchors.Queries;
 using TTA.BusinessLogic.Features.Tournaments.Queries;
+using TTA.BusinessLogic.Services.Api;
+using TTA.Common.Enums;
 using TTA.WebAPI.Authorization;
 using TTA.WebAPI.Extensions;
 
@@ -22,6 +27,7 @@ namespace TTA.WebAPI.Controllers;
 /// Initializes a new instance of the <see cref="MatchesController"/> class.
 /// </remarks>
 /// <param name="mediator">The mediator instance for dispatching commands and queries.</param>
+/// <param name="accessService">Service for validating user access and permissions related to matches.</param>  
 /// <param name="logger">The logger instance for diagnostic information.</param>
 /// <param name="auth0Settings">The settings for Auth0 authentication.</param>
 [Authorize]
@@ -29,10 +35,12 @@ namespace TTA.WebAPI.Controllers;
 [Route("api/[controller]")]
 public class MatchesController(
     IMediator mediator,
+    IAccessService accessService,
     ILogger<MatchesController> logger,
     Auth0Settings auth0Settings) : ControllerBase
 {
     private readonly IMediator _mediator = mediator;
+    private readonly IAccessService _accessService = accessService;
     private readonly ILogger<MatchesController> _logger = logger;
     private readonly Auth0Settings _auth0Settings = auth0Settings;
 
@@ -243,6 +251,7 @@ public class MatchesController(
 
         // 1. Validate the request DTO
         var validationResult = await validator.ValidateAsync(request);
+
         if (!validationResult.IsValid)
         {
             _logger.LogWarning("Validation failed for RecordMatchResultRequest {Id}: {Errors}.", id, validationResult.Errors);
@@ -280,7 +289,7 @@ public class MatchesController(
     [HttpGet("{matchId:guid}/events")]
     [ProducesResponseType(typeof(IEnumerable<GameEventResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMatchEvents(Guid matchId)
+    public async Task<IActionResult> GetMatchEvents([FromRoute] Guid matchId)
     {
         _logger.LogInformation("Retrieving event timeline for match {MatchId}.", matchId);
         // Note: The query handler handles match existence and returns an empty list or throws if necessary.
@@ -295,21 +304,38 @@ public class MatchesController(
     /// <param name="matchId">The unique identifier of the match.</param>
     /// <param name="teamId">The unique identifier of the team.</param>
     /// <param name="request">The request containing details of the game event to be recorded.</param>
+    /// <param name="validator">The validator for the create game event request.</param>
     /// <returns>A <see cref="Guid"/> representing the newly created game event.</returns>
     /// <response code="201">If the game event was successfully created.</response>
+    /// <response code="400">If the request is invalid.</response>
     /// <response code="403">If the user is not authorized to create the game event.</response>
     /// <response code="404">If the match or team is not found.</response>
     /// <response code="409">If there is a conflict with the current state of the resource.</response>
     [HttpPost("{matchId:guid}/teams/{teamId:guid}/events")]
     [Authorize(Policy = "TeamEditor")]
     [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> RecordMatchEventByTeam(Guid matchId, Guid teamId, [FromBody] CreateGameEventRequest request)
+    public async Task<IActionResult> RecordMatchEventByTeam(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid teamId,
+        [FromBody] CreateGameEventRequest request,
+        [FromServices] IValidator<CreateGameEventRequest> validator)
     {
         _logger.LogInformation("Team {TeamId} is recording a new event for match {MatchId}.", teamId, matchId);
 
+        // 1. Validate the request DTO
+        var validationResult = await validator.ValidateAsync(request);
+
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for CreateGameEventRequest for match with {Id}: {Errors}.", matchId, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Verify that the team is actually a participant in this specific match
         var lineup = await _mediator.Send(new GetMatchLineupByIdQuery(request.MatchLineupId));
 
         if (lineup == null)
@@ -318,6 +344,7 @@ public class MatchesController(
         if (lineup.MatchId != matchId || lineup.TeamId != teamId)
             return Forbid();
 
+        // 3. Map request to command and execute
         var command = request.ToCommand(matchId);
         var result = await _mediator.Send(command);
 
@@ -329,21 +356,39 @@ public class MatchesController(
     /// </summary>
     /// <param name="matchId">The unique identifier of the match.</param>
     /// <param name="request">The request containing details of the game event to be recorded.</param>
+    /// <param name="validator">The validator for the create game event request.</param>
     /// <returns>A <see cref="Guid"/> representing the newly created game event.</returns>
     /// <response code="201">If the game event was successfully created.</response>
+    /// <response code="400">If the request is invalid.</response>
     /// <response code="403">If the user is not the owner of the tournament.</response>
     /// <response code="404">If the match is not found.</response>
     /// <response code="409">If there is a conflict with the current state of the resource.</response>
     [HttpPost("{matchId:guid}/events")]
     [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> RecordMatchEvent(Guid matchId, [FromBody] CreateGameEventRequest request)
+    public async Task<IActionResult> RecordMatchEvent(
+        [FromRoute] Guid matchId,
+        [FromBody] CreateGameEventRequest request,
+        [FromServices] IValidator<CreateGameEventRequest> validator)
     {
+        _logger.LogInformation("Recording a new event for match {MatchId} by tournament organizer.", matchId);
+
+        // 1. Validate the request DTO
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for CreateGameEventRequest for match with {Id}: {Errors}.", matchId, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Authorization: Validate that the current user is the owner of the tournament associated with this match
         var accessError = await ValidateTournamentOwnership(matchId);
         if (accessError != null) return accessError;
 
+        // 3. Verify that the lineup entry exists and belongs to the correct match (additional integrity check)
         var lineup = await _mediator.Send(new GetMatchLineupByIdQuery(request.MatchLineupId));
 
         if (lineup == null)
@@ -352,6 +397,7 @@ public class MatchesController(
             return NotFound($"The specified lineup entry {request.MatchLineupId} was not found.");
         }
 
+        // 4. Map request to command and execute
         var command = request.ToCommand(matchId);
         var result = await _mediator.Send(command);
 
@@ -366,21 +412,39 @@ public class MatchesController(
     /// <param name="teamId">The unique identifier of the team.</param>
     /// <param name="id">The unique identifier of the game event to update.</param>
     /// <param name="request">The request containing updated details of the game event.</param>
+    /// <param name="validator">The validator for the update request.</param>
     /// <returns>A <see cref="GameEventResponse"/> representing the updated game event.</returns>
     /// <response code="200">If the game event was successfully updated.</response>
+    /// <response code="400">If the request is invalid.</response>
     /// <response code="403">If the user is not authorized to update the game event.</response>
     /// <response code="404">If the game event is not found.</response>
     /// <response code="409">If there is a conflict with the current state of the resource.</response>
     [HttpPut("{matchId:guid}/teams/{teamId:guid}/events/{id:guid}")]
     [Authorize(Policy = "TeamEditor")]
     [ProducesResponseType(typeof(GameEventResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> UpdateMatchEventByTeam(Guid matchId, Guid teamId, Guid id, [FromBody] UpdateGameEventRequest request)
+    public async Task<IActionResult> UpdateMatchEventByTeam(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid teamId,
+        [FromRoute] Guid id,
+        [FromBody] UpdateGameEventRequest request,
+        [FromServices] IValidator<UpdateGameEventRequest> validator)
     {
         _logger.LogInformation("Team {TeamId} is updating event {Id} in match {MatchId}.", teamId, id, matchId);
 
+        // 1. Validate the request DTO
+        var validationResult = await validator.ValidateAsync(request);
+
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for UpdateGameEventRequest for event {Id}: {Errors}.", id, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Verify that the team is actually a participant in this specific match
         var lineup = await _mediator.Send(new GetMatchLineupByIdQuery(request.MatchLineupId));
 
         if (lineup == null)
@@ -389,6 +453,7 @@ public class MatchesController(
         if (lineup.MatchId != matchId || lineup.TeamId != teamId)
             return Forbid();
 
+        // 3. Map request to command and execute
         var command = request.ToCommand(id, matchId);
         var result = await _mediator.Send(command);
 
@@ -401,21 +466,41 @@ public class MatchesController(
     /// <param name="matchId">The unique identifier of the match.</param>
     /// <param name="id">The unique identifier of the game event to update.</param>
     /// <param name="request">The request containing updated details of the game event.</param>
+    /// <param name="validator">The validator for the update request.</param>
     /// <returns>A <see cref="GameEventResponse"/> representing the updated game event.</returns>
     /// <response code="200">If the game event was successfully updated.</response>
+    /// <response code="400">If the request is invalid.</response>
     /// <response code="403">If the user is not authorized to update the game event.</response>
     /// <response code="404">If the game event is not found.</response>
     /// <response code="409">If there is a conflict with the current state of the resource.</response>
     [HttpPut("{matchId:guid}/events/{id:guid}")]
     [ProducesResponseType(typeof(GameEventResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> UpdateMatchEvent(Guid matchId, Guid id, [FromBody] UpdateGameEventRequest request)
+    public async Task<IActionResult> UpdateMatchEvent(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid id,
+        [FromBody] UpdateGameEventRequest request,
+        [FromServices] IValidator<UpdateGameEventRequest> validator)
     {
+        _logger.LogInformation("Updating event {Id} for match {MatchId} by tournament organizer.", id, matchId);
+
+        // 1. Validate the request DTO
+        var validationResult = await validator.ValidateAsync(request);
+
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for UpdateGameEventRequest for event {Id}: {Errors}.", id, validationResult.Errors);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Authorization: Validate that the current user is the owner of the tournament associated with this match
         var accessError = await ValidateTournamentOwnership(matchId);
         if (accessError != null) return accessError;
 
+        // 3. Verify that the lineup entry exists and belongs to the correct match (additional integrity check)
         var lineup = await _mediator.Send(new GetMatchLineupByIdQuery(request.MatchLineupId));
 
         if (lineup == null)
@@ -424,6 +509,7 @@ public class MatchesController(
             return NotFound($"The specified lineup entry {request.MatchLineupId} was not found.");
         }
 
+        // 4. Map request to command and execute
         var command = request.ToCommand(id, matchId);
         var result = await _mediator.Send(command);
 
@@ -448,7 +534,10 @@ public class MatchesController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteMatchEventByTeam(Guid matchId, Guid teamId, Guid id)
+    public async Task<IActionResult> DeleteMatchEventByTeam(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid teamId,
+        [FromRoute] Guid id)
     {
         _logger.LogInformation("Team {TeamId} is attempting to delete event {Id} in match {MatchId}.", teamId, id, matchId);
 
@@ -472,11 +561,142 @@ public class MatchesController(
             return Forbid();
         }
 
+        // 4. Proceed with deletion
         await _mediator.Send(new DeleteGameEventCommand(id));
+
         return NoContent();
     }
 
     #endregion
+
+    #region Time Anchors
+
+    // ==========================================================================================
+    // Time Anchors Section
+    // ==========================================================================================
+
+    /// <summary>
+    /// Retrieves the complete chronological timeline of anchors recorded for a specific match.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A collection of time anchor details.</returns>
+    /// <response code="200">Returns the list of time anchors.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="404">If the match or associated entities were not found.</response>
+    [AllowAnonymous]
+    [HttpGet("{matchId}/anchors")]
+    [ProducesResponseType(typeof(IEnumerable<TimeAnchorResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetMatchAnchors(Guid matchId, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Retrieving time anchors for match {MatchId}.", matchId);
+        var anchors = await _mediator.Send(new GetMatchAnchorsQuery(matchId), cancellationToken);
+
+        return Ok(anchors);
+    }
+
+    /// <summary>
+    /// Retrieves a specific time anchor record by its unique identifier.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match (from route context).</param>
+    /// <param name="id">The unique identifier of the time anchor.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The detailed representation of the requested time anchor.</returns>
+    /// <response code="200">Returns the requested time anchor.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="404">If the time anchor or associated match was not found.</response>
+    [AllowAnonymous]
+    [HttpGet("{matchId}/anchors/{id}")]
+    [ProducesResponseType(typeof(TimeAnchorResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTimeAnchorById(Guid matchId, Guid id, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Retrieving time anchor {Id} for match {MatchId}.", id, matchId);
+        var anchor = await _mediator.Send(new GetTimeAnchorByIdQuery(id), cancellationToken);
+
+        return Ok(anchor);
+    }
+
+    /// <summary>
+    /// Records a new time anchor for a match timeline.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match from the route.</param>
+    /// <param name="request">The data transfer object containing anchor specifications.</param>
+    /// <param name="validator">The request validator injected from DI container.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The unique identifier of the newly created time anchor record.</returns>
+    /// <response code="201">Returns the unique identifier of the newly created time anchor.</response>
+    /// <response code="400">If the request is invalid.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user is not authorized to perform this action.</response>
+    /// <response code="404">If the match or associated entities were not found.</response>
+    [HttpPost("{matchId}/anchors")]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RecordTimeAnchor(
+        Guid matchId,
+        [FromBody] CreateTimeAnchorRequest request,
+        [FromServices] IValidator<CreateTimeAnchorRequest> validator,
+        CancellationToken cancellationToken)
+    {
+        // 1) Execute FluentValidation rules against the incoming request model
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for CreateTimeAnchorRequest in match {MatchId}.", matchId);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2) Verify user authorization rules (Tournament Owner or competing Team Editors)
+        var authResult = await ValidateMatchEditAccess(matchId, cancellationToken);
+        if (authResult != null) return authResult;
+
+        // 3) Map the validated request DTO to the corresponding command and execute it
+        var command = request.ToCommand(matchId);
+        var result = await _mediator.Send(command, cancellationToken);
+
+        return StatusCode(StatusCodes.Status201Created, result);
+    }
+
+    /// <summary>
+    /// Permanently removes a specific time anchor record from the match timeline.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match from the route.</param>
+    /// <param name="id">The unique identifier of the time anchor to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An empty response indicating successful processing.</returns>
+    /// <response code="204">Indicates successful deletion of the time anchor.</response>
+    /// <response code="401">If the user is not authenticated.</response>
+    /// <response code="403">If the user is not authorized to perform this action.</response>
+    /// <response code="404">If the time anchor or associated match was not found.</response>
+    [HttpDelete("{matchId}/anchors/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteTimeAnchor(Guid matchId, Guid id, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Attempting to delete time anchor {Id} from match {MatchId}.", id, matchId);
+
+        // Verify user authorization rules before performing destructive database changes
+        var authResult = await ValidateMatchEditAccess(matchId, cancellationToken);
+        if (authResult != null) return authResult;
+
+        // Note: The handler for DeleteTimeAnchorCommand handles existence check and throws NotFoundException if anchor is missing,
+        await _mediator.Send(new DeleteTimeAnchorCommand(id), cancellationToken);
+
+        return NoContent();
+    }
+
+    #endregion
+
+    #region Helper Methods
 
     /// <summary>
     /// Validates if the current user is the owner of the tournament associated with the given match.
@@ -506,4 +726,64 @@ public class MatchesController(
 
         return null;
     }
+
+    /// <summary>
+    /// Validates if the current user has permission to modify the match data.
+    /// Authorized roles: Tournament Owner OR Team Editors for either of the competing teams.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the match.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="IActionResult"/> representing the error (NotFound or Forbid), or null if validation passes.</returns>
+    private async Task<IActionResult?> ValidateMatchEditAccess(Guid matchId, CancellationToken cancellationToken = default)
+    {
+        // Fetch match details to retrieve tournament and team identifiers
+        var match = await _mediator.Send(new GetMatchByIdWithDetailsQuery(matchId), cancellationToken);
+
+        // Verify associated tournament existence and ownership
+        var tournament = await _mediator.Send(new GetTournamentByIdQuery(match.TournamentId), cancellationToken);
+        if (tournament == null)
+        {
+            _logger.LogWarning("Validation failed: Associated tournament for match {MatchId} not found.", matchId);
+            return NotFound("Associated tournament not found.");
+        }
+
+        string userId = this.GetUserId(_auth0Settings);
+        if (tournament.OwnerId == userId)
+        {
+            // User is the tournament creator -> Access Granted immediately
+            return null;
+        }
+
+        // Check Team Editor rights for the Home Team
+        bool isHomeEditor = await _accessService.HasAccessAsync(
+            userId,
+            AppRole.Editor,
+            TargetScope.Team,
+            match.HomeTeamId,
+            cancellationToken);
+
+        if (isHomeEditor)
+        {
+            return null; // Access Granted
+        }
+
+        // Check Team Editor rights for the Guest Team (Correction: Using GuestTeamId from MatchWithDetailsResponse)
+        bool isGuestEditor = await _accessService.HasAccessAsync(
+            userId,
+            AppRole.Editor,
+            TargetScope.Team,
+            match.GuestTeamId,
+            cancellationToken);
+
+        if (isGuestEditor)
+        {
+            return null; // Access Granted
+        }
+
+        // If none of the conditions above are met -> Access Denied
+        _logger.LogWarning("User {UserId} is not authorized to modify match {MatchId}.", userId, matchId);
+        return Forbid();
+    }
+
+    #endregion
 }

--- a/TTA.WebAPI/Controllers/TournamentsController.cs
+++ b/TTA.WebAPI/Controllers/TournamentsController.cs
@@ -54,18 +54,20 @@ public class TournamentsController(
     {
         _logger.LogInformation("Executing Create action for tournament: {Name}.", request.Name);
 
+        // 1) Validate the incoming request
         var validationResult = await validator.ValidateAsync(request);
+
         if (!validationResult.IsValid)
         {
             _logger.LogWarning("Validation failed for CreateTournamentRequest: {Errors}.", validationResult.Errors);
             return BadRequest(validationResult.Errors);
         }
 
-        // Get User Id from custom claim
+        // 2) Get User Id from custom claim
         string userId = this.GetUserId(_auth0Settings);
 
+        // 3) Map the request to a command and send it to the mediator
         var command = request.ToCommand(userId);
-
         var result = await _mediator.Send(command);
 
         return StatusCode(StatusCodes.Status201Created, result);
@@ -98,18 +100,20 @@ public class TournamentsController(
     {
         _logger.LogInformation("Executing Update action for tournament {Id}: {Name}.", id, request.Name);
 
+        // 1) Validate the incoming request
         var validationResult = await validator.ValidateAsync(request);
+
         if (!validationResult.IsValid)
         {
             _logger.LogWarning("Validation failed for UpdateTournamentRequest {Id}: {Errors}.", id, validationResult.Errors);
             return BadRequest(validationResult.Errors);
         }
 
-        // Get User Id from custom claim
+        // 2) Get User Id from custom claim
         string userId = this.GetUserId(_auth0Settings);
 
+        // 3) Map the request to a command and send it to the mediator
         var command = request.ToCommand(id, userId);
-
         var result = await _mediator.Send(command);
 
         return Ok(result);
@@ -144,6 +148,7 @@ public class TournamentsController(
     /// <summary>
     /// Schedules a new match.
     /// </summary>
+    /// <param name="tournamentId">The unique identifier of the tournament.</param>
     /// <param name="request">The match creation request data.</param>
     /// <param name="validator">The validator for the creation request.</param>
     /// <returns>The newly created match entity.</returns>
@@ -169,6 +174,7 @@ public class TournamentsController(
 
         // 1) Validate the incoming request
         var validationResult = await validator.ValidateAsync(request);
+
         if (!validationResult.IsValid)
         {
             _logger.LogWarning("Validation failed for ScheduleMatchRequest in tournament with ID: {TournamentId}. Errors: {Errors}.", tournamentId, validationResult.Errors);
@@ -222,6 +228,7 @@ public class TournamentsController(
             return NotFound();
         }
 
+        // If tournament exists, retrieve matches
         var query = new GetTournamentMatchesQuery(tournamentId);
         var result = await _mediator.Send(query);
 

--- a/TTA.WebAPI/Startup.cs
+++ b/TTA.WebAPI/Startup.cs
@@ -123,6 +123,7 @@ public static class Startup
         services.AddScoped<IMatchRepository, MatchRepository>();
         services.AddScoped<IMatchLineupRepository, MatchLineupRepository>();
         services.AddScoped<IGameEventRepository, GameEventRepository>();
+        services.AddScoped<ITimeAnchorRepository, TimeAnchorRepository>();
 
         services.AddSingleton<IDbConnectionFactory, NpgsqlConnectionFactory>();
 


### PR DESCRIPTION
# 📝 Pull Request: Time Anchors Implementation (Match Timeline Control)

## 🔗 Related Issue
Resolves #47

## 🎯 Purpose and Context
This PR introduces the **TimeAnchor** module. Time anchors are critical for capturing real-world timestamps of match events such as Period Start, Period End, and Stoppages. 
This data serves as the foundation for the upcoming "Piecewise-Linear" normalization logic that will convert real-time stamps into "Clean Time" (`NormalizedMatchTime`).

## ✨ Key Changes

### 1. Database & Repository Layer
* **SQL Storage Procedures:** Added `public.upsert_time_anchor`, `public.get_time_anchor_by_id`, `public.get_match_anchors`, and `public.delete_time_anchor` to `02-Storage-procedures.sql`.
* **Constants:** Added `SqlStatements.ForTimeAnchors` to map SQL calls.
* **Repository:** Created `ITimeAnchorRepository` and its Dapper implementation `TimeAnchorRepository` to handle data access operations efficiently without bypassing the storage functions.

### 2. Business Logic (DTOs, Validation & MediatR Handlers)
* **DTOs:** Introduced `CreateTimeAnchorRequest` and `TimeAnchorResponse`.
* **Validation:** Added `CreateTimeAnchorRequestValidator` (FluentValidation) to enforce `PeriodNumber > 0` and valid `TimeAnchorType` enums.
* **Commands/Queries:**
    * `CreateTimeAnchorHandler`: Includes strict state-machine validation to prevent illogical sequences (e.g., starting a stoppage when the match is already stopped).
    * `DeleteTimeAnchorHandler`, `GetMatchAnchorsHandler`, and `GetTimeAnchorByIdHandler` implemented with appropriate exception mapping (`NotFoundException`, `ConflictException`).

### 3. API Layer
* **MatchesController Extensions:**
    * `POST /api/matches/{matchId}/anchors`
    * `GET /api/matches/{matchId}/anchors`
    * `GET /api/matches/{matchId}/anchors/{id}`
    * `DELETE /api/matches/{matchId}/anchors/{id}`
* **Security:** Added specific access validation ensuring that `POST` and `DELETE` operations can only be performed by the Tournament Owner or a user with `TeamEditor` rights for participating teams. (Requires `IAccessService` enhancements).

### 4. Testing
* **Unit Tests:** Comprehensive coverage added for MediatR handlers (creation, deletion, retrieval) and DTO validators ensuring correct business rule enforcement and error throwing.
* **Integration Tests:** Added `TimeAnchorRepositoryTests` and extended `MatchesControllerTests` to verify database interactions, JSON serialization (enum handling), and endpoint security.

## 🧪 Testing Scope
- [x] **Unit tests:** Verified MediatR handlers sequence logic and FluentValidation rules.
- [x] **Integration tests:** Ensured accurate DB state tracking via `TimeAnchorRepositoryTests` and endpoint security/routing in `MatchesControllerTests`.
- [x] **Authorization:** Verified that only users with valid constraints (Tournament Owner or Editor) can invoke POST/DELETE operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time Anchors: create, list, retrieve and delete match timeline markers (period starts/ends, stoppages) via new endpoints
  * Time Anchors: server returns chronological anchor timelines and per-anchor details
  * Game events: clients no longer provide event timestamps; events are server-timestamped; added "Lead to Goal" flag

* **Improvements**
  * API: clearer route binding and consistent request validation for match and game-event endpoints
  * Authorization: refined match-edit access checks supporting tournament owners and team editors

* **Validation**
  * Create game-event requests no longer validate or require client-supplied timestamps; time-anchor request validation added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HlibBondarev/TTA-backend/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->