### PR TITLE
Feature - Player Time-in-Match Performance Analytics

### DIFF
--- a/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
@@ -1,0 +1,124 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TTA.BusinessLogic.Features.PlayerPresences.Handlers;
+using TTA.BusinessLogic.Features.PlayerPresences.Queries;
+using TTA.BusinessLogic.Services.Api;
+using TTA.DataAccess.Repository.Api;
+using TTA.DataAccess.Repository.Projections;
+
+namespace TTA.BusinessLogic.Tests.Features.PlayerPresences.Handlers;
+
+/// <summary>
+/// Unit tests for the <see cref="GetPlayersTimeInMatchQueryHandler"/> class.
+/// Validates database projection aggregation, analytical mathematical equations, and mapping logic.
+/// </summary>
+public class GetPlayersTimeInMatchQueryHandlerTests
+{
+    private readonly Mock<IPlayerPresenceRepository> _playerPresenceRepositoryMock;
+    private readonly Mock<ITimeNormalizationService> _timeNormalizationServiceMock;
+    private readonly Mock<ILogger<GetPlayersTimeInMatchQueryHandler>> _loggerMock;
+    private readonly GetPlayersTimeInMatchQueryHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetPlayersTimeInMatchQueryHandlerTests"/> class.
+    /// Sets up required mock instances and instantiates the target system handler under test.
+    /// </summary>
+    public GetPlayersTimeInMatchQueryHandlerTests()
+    {
+        _playerPresenceRepositoryMock = new Mock<IPlayerPresenceRepository>();
+        _timeNormalizationServiceMock = new Mock<ITimeNormalizationService>();
+        _loggerMock = new Mock<ILogger<GetPlayersTimeInMatchQueryHandler>>();
+
+        _handler = new GetPlayersTimeInMatchQueryHandler(
+            _playerPresenceRepositoryMock.Object,
+            _timeNormalizationServiceMock.Object,
+            _loggerMock.Object
+        );
+    }
+
+    /// <summary>
+    /// Verifies that the handler yields an empty collection cleanly when the repository layer returns no matching rows.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_ReturnEmptyCollection_When_NoProjectionsFound()
+    {
+        // Arrange
+        var query = new GetPlayersTimeInMatchQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _playerPresenceRepositoryMock
+            .Setup(r => r.GetPlayersDirtyTimeByPeriodAsync(query.MatchId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<PlayersDirtyTimeByPeriodProjection>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+
+        _timeNormalizationServiceMock
+            .Verify(s => s.GetNormalizedTimeCoefficientAsync(It.IsAny<Guid>(), It.IsAny<int>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that the handler correctly groups rows by player, requests period coefficients, 
+    /// processes the time transformation equation, and accurately sums metrics across multiple periods.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_CalculateCorrectAggregatedTimes_When_ProjectionsExist()
+    {
+        // Arrange
+        var query = new GetPlayersTimeInMatchQuery(Guid.NewGuid(), Guid.NewGuid());
+        var playerLineupIdA = Guid.NewGuid();
+        var playerLineupIdB = Guid.NewGuid();
+
+        // Projections setup: 
+        // Player A played in Period 1 (300s) and Period 2 (200s)
+        // Player B played only in Period 1 (150s)
+        var databaseProjections = new List<PlayersDirtyTimeByPeriodProjection>
+        {
+            new(playerLineupIdA, 1, 300.0),
+            new(playerLineupIdA, 2, 200.0),
+            new(playerLineupIdB, 1, 150.0)
+        };
+
+        _playerPresenceRepositoryMock
+            .Setup(r => r.GetPlayersDirtyTimeByPeriodAsync(query.MatchId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(databaseProjections);
+
+        // Scale coefficients setup: Period 1 K = 0.8, Period 2 K = 1.2
+        _timeNormalizationServiceMock
+            .Setup(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1))
+            .ReturnsAsync(0.8);
+
+        _timeNormalizationServiceMock
+            .Setup(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 2))
+            .ReturnsAsync(1.2);
+
+        // Act
+        var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+
+        // Verify Player A Calculations:
+        // Dirty time: 300 + 200 = 500 seconds
+        // Clean time: (300 * 0.8) + (200 * 1.2) = 240 + 240 = 480 seconds
+        var playerResultA = result.SingleOrDefault(r => r.MatchLineupId == playerLineupIdA);
+        playerResultA.Should().NotBeNull();
+        playerResultA!.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(500));
+        playerResultA.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(480));
+
+        // Verify Player B Calculations:
+        // Dirty time: 150 seconds
+        // Clean time: 150 * 0.8 = 120 seconds
+        var playerResultB = result.SingleOrDefault(r => r.MatchLineupId == playerLineupIdB);
+        playerResultB.Should().NotBeNull();
+        playerResultB!.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(150));
+        playerResultB.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(120));
+
+        // Verify service optimization: coefficient methods are hit exactly once per distinct period index
+        _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1), Times.Once);
+        _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 2), Times.Once);
+    }
+}

--- a/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
@@ -121,4 +121,46 @@ public class GetPlayersTimeInMatchQueryHandlerTests
         _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1), Times.Once);
         _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 2), Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that the handler gracefully degrades and falls back to raw linear time for a specific period
+    /// if the <see cref="ITimeNormalizationService"/> throws an exception during coefficient pre-fetching loops.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_FallbackToRawLinearTime_When_NormalizationServiceThrowsException()
+    {
+        // Arrange
+        var query = new GetPlayersTimeInMatchQuery(Guid.NewGuid(), Guid.NewGuid());
+        var playerLineupId = Guid.NewGuid();
+
+        // Setup mock to return a single track record
+        var databaseProjections = new List<PlayersDirtyTimeByPeriodProjection>
+        {
+            new(playerLineupId, 1, 300.0)
+        };
+
+        _playerPresenceRepositoryMock
+            .Setup(r => r.GetPlayersDirtyTimeByPeriodAsync(query.MatchId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(databaseProjections);
+
+        // Simulate service failure (e.g., missing anchors or division by zero condition)
+        _timeNormalizationServiceMock
+            .Setup(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1))
+            .ThrowsAsync(new InvalidOperationException("Missing matching time anchors for the specified period."));
+
+        // Act
+        var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+
+        var playerResult = result.Single();
+        playerResult.MatchLineupId.Should().Be(playerLineupId);
+        playerResult.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(300));
+
+        // Due to the catch block, coefficient mapping is missing, triggering a 1:1 raw fallback calculation step
+        playerResult.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(300));
+
+        _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1), Times.Once);
+    }
 }

--- a/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandlerTests.cs
@@ -163,4 +163,54 @@ public class GetPlayersTimeInMatchQueryHandlerTests
 
         _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1), Times.Once);
     }
+
+    /// <summary>
+    /// Verifies that the handler accurately aggregates performance records in a mixed scenario where one match period 
+    /// normalizes successfully and another period throws an exception, confirming partial fallback and accumulation stability.
+    /// </summary>
+    [Fact]
+    public async Task Handle_Should_CalculateMixedTimes_When_OnePeriodSucceedsAndAnotherThrows()
+    {
+        // Arrange
+        var query = new GetPlayersTimeInMatchQuery(Guid.NewGuid(), Guid.NewGuid());
+        var playerLineupId = Guid.NewGuid();
+
+        // Setup mock projections: Player A plays in Period 1 (300s) and Period 2 (200s)
+        var databaseProjections = new List<PlayersDirtyTimeByPeriodProjection>
+        {
+            new(playerLineupId, 1, 300.0),
+            new(playerLineupId, 2, 200.0)
+        };
+
+        _playerPresenceRepositoryMock
+            .Setup(r => r.GetPlayersDirtyTimeByPeriodAsync(query.MatchId, query.TeamId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(databaseProjections);
+
+        // Period 1 succeeds with an analytical coefficient K = 0.8
+        _timeNormalizationServiceMock
+            .Setup(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1))
+            .ReturnsAsync(0.8);
+
+        // Period 2 throws an exception simulating missing anchors or configuration errors
+        _timeNormalizationServiceMock
+            .Setup(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 2))
+            .ThrowsAsync(new InvalidOperationException("Missing matching anchors for period 2."));
+
+        // Act
+        var result = (await _handler.Handle(query, CancellationToken.None)).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+
+        // Verify Mixed Partial Accumulation Calculations:
+        // Total Dirty time: 300 + 200 = 500 seconds
+        // Total Clean time: (300 * 0.8) + (200 raw 1:1 fallback) = 240 + 200 = 440 seconds
+        var playerResult = result.Single();
+        playerResult.MatchLineupId.Should().Be(playerLineupId);
+        playerResult.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(500));
+        playerResult.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(440));
+
+        _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 1), Times.Once);
+        _timeNormalizationServiceMock.Verify(s => s.GetNormalizedTimeCoefficientAsync(query.MatchId, 2), Times.Once);
+    }
 }

--- a/TTA.BusinessLogic.Tests/Features/PlayerPresences/Validators/PlayerTimeInMatchRequestValidatorTests.cs
+++ b/TTA.BusinessLogic.Tests/Features/PlayerPresences/Validators/PlayerTimeInMatchRequestValidatorTests.cs
@@ -1,0 +1,73 @@
+﻿using FluentValidation.TestHelper;
+using TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+using TTA.BusinessLogic.Features.PlayerPresences.Validators;
+
+namespace TTA.BusinessLogic.Tests.Features.PlayerPresences.Validators;
+
+/// <summary>
+/// Unit tests for the <see cref="PlayerTimeInMatchRequestValidator"/> class.
+/// Validates constraints and correctness rules for analytical request payloads.
+/// </summary>
+public class PlayerTimeInMatchRequestValidatorTests
+{
+    private readonly PlayerTimeInMatchRequestValidator _validator = new();
+
+    /// <summary>
+    /// Verifies that the validator does not yield any errors when both MatchId and TeamId are valid, non-empty GUIDs.
+    /// </summary>
+    [Fact]
+    public void Validator_Should_NotHaveErrors_When_RequestIsValid()
+    {
+        // Arrange
+        var request = new PlayerTimeInMatchRequest(
+            MatchId: Guid.NewGuid(),
+            TeamId: Guid.NewGuid()
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    /// <summary>
+    /// Verifies that a validation error is generated when the <see cref="PlayerTimeInMatchRequest.MatchId"/> is an empty GUID.
+    /// </summary>
+    [Fact]
+    public void Validator_Should_HaveError_When_MatchIdIsEmpty()
+    {
+        // Arrange
+        var request = new PlayerTimeInMatchRequest(
+            MatchId: Guid.Empty,
+            TeamId: Guid.NewGuid()
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.MatchId)
+            .WithErrorMessage("MatchId must be a valid, non-empty GUID.");
+    }
+
+    /// <summary>
+    /// Verifies that a validation error is generated when the <see cref="PlayerTimeInMatchRequest.TeamId"/> is an empty GUID.
+    /// </summary>
+    [Fact]
+    public void Validator_Should_HaveError_When_TeamIdIsEmpty()
+    {
+        // Arrange
+        var request = new PlayerTimeInMatchRequest(
+            MatchId: Guid.NewGuid(),
+            TeamId: Guid.Empty
+        );
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.TeamId)
+            .WithErrorMessage("TeamId must be a valid, non-empty GUID.");
+    }
+}

--- a/TTA.BusinessLogic/Features/PlayerPresences/DTOs/PlayerTimeInMatchRequest.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/DTOs/PlayerTimeInMatchRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+
+/// <summary>
+/// Request parameters model used for API parameter binding to calculate player time-in-match performance analytics.
+/// </summary>
+/// <param name="MatchId">The unique database reference key for the target match.</param>
+/// <param name="TeamId">The unique reference key for the target team.</param>
+public record PlayerTimeInMatchRequest(
+    Guid MatchId,
+    Guid TeamId
+);

--- a/TTA.BusinessLogic/Features/PlayerPresences/DTOs/PlayerTimeInMatchResponse.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/DTOs/PlayerTimeInMatchResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+
+/// <summary>
+/// Represents the calculated performance analytics response containing clean and dirty play times for a specific match lineup record.
+/// </summary>
+/// <param name="MatchLineupId">The unique database reference identifier for the player's match lineup record.</param>
+/// <param name="CleanTimeInMatch">The calculated clean active play time after normalization adjustments.</param>
+/// <param name="DirtyTimeInMatch">The raw linear elapsed time spent in the match before adjustments.</param>
+public record PlayerTimeInMatchResponse(
+    Guid MatchLineupId,
+    TimeSpan CleanTimeInMatch,
+    TimeSpan DirtyTimeInMatch
+);

--- a/TTA.BusinessLogic/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandler.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandler.cs
@@ -49,8 +49,17 @@ public class GetPlayersTimeInMatchQueryHandler(
 
         foreach (var periodNumber in uniquePeriods)
         {
-            double coefficientK = await _timeNormalizationService.GetNormalizedTimeCoefficientAsync(request.MatchId, periodNumber);
-            periodCoefficients[periodNumber] = coefficientK;
+            try
+            {
+                double coefficientK = await _timeNormalizationService.GetNormalizedTimeCoefficientAsync(request.MatchId, periodNumber);
+                periodCoefficients[periodNumber] = coefficientK;
+            }
+            catch (Exception ex)
+            {
+                // CodeRabbit Fix: Prevent a single period normalization error from aborting the entire request.
+                // Incomplete matches or missing anchors will degrade gracefully using the fallback path.
+                _logger.LogWarning(ex, "Failed to retrieve normalization coefficient for Match {MatchId}, Period {PeriodNumber}. Falling back to raw linear time.", request.MatchId, periodNumber);
+            }
         }
 
         // 3. Group the projection rows by individual player (MatchLineupId)
@@ -73,7 +82,7 @@ public class GetPlayersTimeInMatchQueryHandler(
                 }
                 else
                 {
-                    // Fallback to raw linear time if coefficient map boundary is missed
+                    // Fallback to raw linear time if coefficient map boundary is missed or service lookup threw an error
                     totalCleanSeconds += row.DirtySeconds;
                 }
             }

--- a/TTA.BusinessLogic/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandler.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/Handlers/GetPlayersTimeInMatchQueryHandler.cs
@@ -1,0 +1,93 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+using TTA.BusinessLogic.Features.PlayerPresences.Queries;
+using TTA.BusinessLogic.Services.Api;
+using TTA.DataAccess.Repository.Api;
+
+namespace TTA.BusinessLogic.Features.PlayerPresences.Handlers;
+
+/// <summary>
+/// Handles the execution pipeline for the <see cref="GetPlayersTimeInMatchQuery"/>.
+/// Coordinates data extraction from repositories, triggers time normalization, and calculates final aggregated performance metrics.
+/// </summary>
+/// <param name="playerPresenceRepository">The specific data access repository for reading player field sessions.</param>
+/// <param name="timeNormalizationService">The service used to retrieve piecewise-linear scale coefficients per period.</param>
+/// <param name="logger">The application-scoped diagnostic system component used for debugging context.</param>
+public class GetPlayersTimeInMatchQueryHandler(
+    IPlayerPresenceRepository playerPresenceRepository,
+    ITimeNormalizationService timeNormalizationService,
+    ILogger<GetPlayersTimeInMatchQueryHandler> logger) : IRequestHandler<GetPlayersTimeInMatchQuery, IEnumerable<PlayerTimeInMatchResponse>>
+{
+    private readonly IPlayerPresenceRepository _playerPresenceRepository = playerPresenceRepository;
+    private readonly ITimeNormalizationService _timeNormalizationService = timeNormalizationService;
+    private readonly ILogger<GetPlayersTimeInMatchQueryHandler> _logger = logger;
+
+    /// <summary>
+    /// Processes the player analytics query by extracting dirty time projections, fetching scaling coefficients, and aggregating final times.
+    /// </summary>
+    /// <param name="request">The incoming query payload containing match and team identifiers.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests during processing.</param>
+    /// <returns>A task representing the asynchronous operation, containing a collection of mapped performance responses.</returns>
+    public async Task<IEnumerable<PlayerTimeInMatchResponse>> Handle(GetPlayersTimeInMatchQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting player time-in-match analytical pipeline for Match {MatchId} and Team {TeamId}.", request.MatchId, request.TeamId);
+
+        // 1. Fetch strictly-typed projection rows via repository layer
+        var dirtyTimeProjections = await _playerPresenceRepository.GetPlayersDirtyTimeByPeriodAsync(request.MatchId, request.TeamId, cancellationToken);
+
+        var projectionsList = dirtyTimeProjections.ToList();
+        if (projectionsList.Count == 0)
+        {
+            _logger.LogWarning("No player presence tracking rows found for Match {MatchId}, Team {TeamId}.", request.MatchId, request.TeamId);
+            return Enumerable.Empty<PlayerTimeInMatchResponse>();
+        }
+
+        // 2. Optimization: Pre-fetch scale coefficients 'K' for each unique period in the match scope
+        var uniquePeriods = projectionsList.Select(r => r.PeriodNumber).Distinct().ToList();
+        var periodCoefficients = new Dictionary<int, double>();
+
+        foreach (var periodNumber in uniquePeriods)
+        {
+            double coefficientK = await _timeNormalizationService.GetNormalizedTimeCoefficientAsync(request.MatchId, periodNumber);
+            periodCoefficients[periodNumber] = coefficientK;
+        }
+
+        // 3. Group the projection rows by individual player (MatchLineupId)
+        var groupedByPlayer = projectionsList.GroupBy(r => r.MatchLineupId);
+        var responseAnalytics = new List<PlayerTimeInMatchResponse>();
+
+        foreach (var playerGroup in groupedByPlayer)
+        {
+            double totalDirtySeconds = 0;
+            double totalCleanSeconds = 0;
+
+            foreach (var row in playerGroup)
+            {
+                totalDirtySeconds += row.DirtySeconds;
+
+                // 4. Apply clean time calculation: CleanSeconds = DirtySeconds * K
+                if (periodCoefficients.TryGetValue(row.PeriodNumber, out double coefficientK))
+                {
+                    totalCleanSeconds += row.DirtySeconds * coefficientK;
+                }
+                else
+                {
+                    // Fallback to raw linear time if coefficient map boundary is missed
+                    totalCleanSeconds += row.DirtySeconds;
+                }
+            }
+
+            // 5. Map accumulated metrics into standard .NET TimeSpan instances
+            responseAnalytics.Add(new PlayerTimeInMatchResponse(
+                MatchLineupId: playerGroup.Key,
+                CleanTimeInMatch: TimeSpan.FromSeconds(totalCleanSeconds),
+                DirtyTimeInMatch: TimeSpan.FromSeconds(totalDirtySeconds)
+            ));
+        }
+
+        _logger.LogInformation("Successfully completed performance analytics execution for {Count} players in Match {MatchId}.", responseAnalytics.Count, request.MatchId);
+
+        return responseAnalytics;
+    }
+}

--- a/TTA.BusinessLogic/Features/PlayerPresences/Queries/GetPlayersTimeInMatchQuery.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/Queries/GetPlayersTimeInMatchQuery.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+using TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+
+namespace TTA.BusinessLogic.Features.PlayerPresences.Queries;
+
+/// <summary>
+/// Immutable query record used to initiate the performance analytics pipeline 
+/// that aggregates clean and dirty play times for a team within a match context.
+/// </summary>
+/// <param name="MatchId">The unique database reference key for the target match.</param>
+/// <param name="TeamId">The unique reference key for the target team.</param>
+public record GetPlayersTimeInMatchQuery(Guid MatchId, Guid TeamId) : IRequest<IEnumerable<PlayerTimeInMatchResponse>>;

--- a/TTA.BusinessLogic/Features/PlayerPresences/Validators/PlayerTimeInMatchRequestValidator.cs
+++ b/TTA.BusinessLogic/Features/PlayerPresences/Validators/PlayerTimeInMatchRequestValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+using TTA.BusinessLogic.Features.PlayerPresences.DTOs;
+
+namespace TTA.BusinessLogic.Features.PlayerPresences.Validators;
+
+/// <summary>
+/// Validates boundaries and completeness rules for the <see cref="PlayerTimeInMatchRequest"/> DTO.
+/// </summary>
+public class PlayerTimeInMatchRequestValidator : AbstractValidator<PlayerTimeInMatchRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerTimeInMatchRequestValidator"/> class with specific validation rules.
+    /// </summary>
+    public PlayerTimeInMatchRequestValidator()
+    {
+        RuleFor(x => x.MatchId)
+            .NotEmpty()
+            .WithMessage("MatchId must be a valid, non-empty GUID.");
+
+        RuleFor(x => x.TeamId)
+            .NotEmpty()
+            .WithMessage("TeamId must be a valid, non-empty GUID.");
+    }
+}

--- a/TTA.DataAccess/Repository/Api/IPlayerPresenceRepository.cs
+++ b/TTA.DataAccess/Repository/Api/IPlayerPresenceRepository.cs
@@ -1,5 +1,6 @@
 ﻿using TTA.DataAccess.Models;
 using TTA.DataAccess.Repository.Base;
+using TTA.DataAccess.Repository.Projections;
 
 namespace TTA.DataAccess.Repository.Api;
 
@@ -52,4 +53,13 @@ public interface IPlayerPresenceRepository : IEntityRepositoryBase<Guid, PlayerP
     /// <param name="timeOut">The exact UTC timestamp marking when the period ended, used to close open player sessions.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests during the asynchronous operation.</param>
     Task CloseActivePresencesAsync(Guid matchId, int periodNumber, DateTime timeOut, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the raw linear ("dirty") time spent in the water per player lineup row, grouped by match periods.
+    /// </summary>
+    /// <param name="matchId">The unique database reference key for the target match.</param>
+    /// <param name="teamId">The unique reference key for the target team.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests during the asynchronous operation.</param>
+    /// <returns>A collection of typed projections containing lineup reference, period index, and total dirty seconds.</returns>
+    Task<IEnumerable<PlayersDirtyTimeByPeriodProjection>> GetPlayersDirtyTimeByPeriodAsync(Guid matchId, Guid teamId, CancellationToken cancellationToken = default);
 }

--- a/TTA.DataAccess/Repository/PlayerPresenceRepository.cs
+++ b/TTA.DataAccess/Repository/PlayerPresenceRepository.cs
@@ -2,6 +2,7 @@
 using TTA.DataAccess.Models;
 using TTA.DataAccess.Repository.Api;
 using TTA.DataAccess.Repository.Base;
+using TTA.DataAccess.Repository.Projections;
 
 namespace TTA.DataAccess.Repository;
 
@@ -98,6 +99,20 @@ public class PlayerPresenceRepository(IDbConnectionFactory connectionFactory)
         using var connection = await OpenConnectionAsync(cancellationToken);
         await connection.ExecuteAsync(new CommandDefinition(
             SqlStatements.ForPlayerPresence.CloseActivePresences,
+            parameters,
+            cancellationToken: cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PlayersDirtyTimeByPeriodProjection>> GetPlayersDirtyTimeByPeriodAsync(Guid matchId, Guid teamId, CancellationToken cancellationToken = default)
+    {
+        var parameters = new DynamicParameters();
+        parameters.Add("p_match_id", matchId);
+        parameters.Add("p_team_id", teamId);
+
+        using var connection = await OpenConnectionAsync(cancellationToken);
+        return await connection.QueryAsync<PlayersDirtyTimeByPeriodProjection>(new CommandDefinition(
+            SqlStatements.ForPlayerPresence.CalculatePlayersDirtyTimeByPeriod,
             parameters,
             cancellationToken: cancellationToken));
     }

--- a/TTA.DataAccess/Repository/Projections/PlayersDirtyTimeByPeriodProjection.cs
+++ b/TTA.DataAccess/Repository/Projections/PlayersDirtyTimeByPeriodProjection.cs
@@ -1,0 +1,15 @@
+﻿namespace TTA.DataAccess.Repository.Projections;
+
+/// <summary>
+/// Represents a flat typed database projection containing raw linear ("dirty") play time 
+/// spent by a player lineup row in a specific match period.
+/// Used to avoid dynamic mapping and guarantee compile-time safety for analytical queries.
+/// </summary>
+/// <param name="MatchLineupId">The unique database identifier for the player's match lineup record.</param>
+/// <param name="PeriodNumber">The specific match period number during which the time was recorded.</param>
+/// <param name="DirtySeconds">The total linear elapsed time in seconds spent in the water.</param>
+public record PlayersDirtyTimeByPeriodProjection(
+    Guid MatchLineupId,
+    int PeriodNumber,
+    double DirtySeconds
+);

--- a/TTA.DataAccess/Repository/SqlStatements.cs
+++ b/TTA.DataAccess/Repository/SqlStatements.cs
@@ -426,5 +426,11 @@ public static class SqlStatements
         /// </summary>
         public const string CloseActivePresences =
             "SELECT public.close_active_presences(@p_match_id, @p_period_number, @p_time_out);";
+
+        /// <summary>
+        /// Invokes the storage function to calculate raw dirty play time by period for a specific team in a match.
+        /// </summary>
+        public const string CalculatePlayersDirtyTimeByPeriod =
+            "SELECT * FROM public.calculate_players_dirty_time_by_period(@p_match_id, @p_team_id);";
     }
 }

--- a/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
@@ -1633,3 +1633,35 @@ BEGIN
       AND pp.periodnumber = p_period_number
       AND pp.timeout IS NULL;
 END;$$ LANGUAGE plpgsql;
+
+/**********************************************************************************
+ * Calculates the total elapsed linear seconds ("dirty" time) spent by each player 
+ * of a specific team in a selected match, grouped by period.
+ * Returns the exact seconds as DOUBLE PRECISION for clean .NET TimeSpan mapping.
+ **********************************************************************************/
+CREATE OR REPLACE FUNCTION public.calculate_players_dirty_time_by_period(
+    p_match_id UUID,
+    p_team_id UUID
+)
+RETURNS TABLE (
+    matchlineupid UUID,
+    periodnumber INT,
+    dirtyseconds DOUBLE PRECISION
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        ml.id AS matchlineupid,
+        pp.periodnumber,
+        SUM(EXTRACT(EPOCH FROM (pp.timeout - pp.timein)))::DOUBLE PRECISION AS dirtyseconds
+    FROM public.playerpresences pp
+    JOIN public.matchlineups ml ON pp.matchlineupid = ml.id
+    LEFT JOIN public.playerrosters pr ON ml.playerrosterid = pr.id
+    WHERE ml.matchid = p_match_id
+      AND (
+          pr.teamid = p_team_id
+          OR (ml.playerrosterid IS NULL AND ml.number = -1 AND (SELECT hometeamid FROM public.matches WHERE id = p_match_id) = p_team_id)
+          OR (ml.playerrosterid IS NULL AND ml.number = -2 AND (SELECT guestteamid FROM public.matches WHERE id = p_match_id) = p_team_id)
+      )
+    GROUP BY ml.id, pp.periodnumber;
+END;$$ LANGUAGE plpgsql;

--- a/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
+++ b/TTA.DataAccess/SQLScripts/02-Storage-procedures.sql
@@ -1653,7 +1653,7 @@ BEGIN
     SELECT 
         ml.id AS matchlineupid,
         pp.periodnumber,
-        SUM(EXTRACT(EPOCH FROM (pp.timeout - pp.timein)))::DOUBLE PRECISION AS dirtyseconds
+        COALESCE(SUM(EXTRACT(EPOCH FROM (pp.timeout - pp.timein))), 0)::DOUBLE PRECISION AS dirtyseconds
     FROM public.playerpresences pp
     JOIN public.matchlineups ml ON pp.matchlineupid = ml.id
     LEFT JOIN public.playerrosters pr ON ml.playerrosterid = pr.id

--- a/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
@@ -879,6 +879,199 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         resultList[1].TimeOut.Should().BeNull();
     }
 
+    /// <summary>
+    /// Verifies that <see cref="MatchesController.GetPlayersTimeInMatchByTeam"/> returns 200 OK 
+    /// with a valid collection of player time responses when the request satisfies all tenancy, validation, and TeamEditor policy rules.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersTimeInMatchByTeam_ShouldReturnOk_WhenRequestIsValidAndTeamBelongsToMatch()
+    {
+        // Arrange
+        var context = await SeedAnalyticsEnvironmentAsync(ownerId: "auth0|different-owner");
+
+        // Grant TeamEditor permission (targettype 2 = Team, role 1 = Editor) to the current test user
+        await GrantAccessPolicyAsync(BaseApiTest.TestUserId, targetType: 2, targetId: context.TeamId, role: 1);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{context.MatchId}/teams/{context.TeamId}/presence/calculate");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var analytics = await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>();
+        analytics.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MatchesController.GetPlayersTimeInMatchByTeam"/> returns 403 Forbidden
+    /// when the requested team ID does not belong to the home or guest team boundaries of the targeted match.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersTimeInMatchByTeam_ShouldReturnForbidden_WhenTeamIdIsOutsideMatchBoundaries()
+    {
+        // Arrange
+        var context = await SeedAnalyticsEnvironmentAsync(ownerId: "auth0|different-owner");
+        var completelyRandomTeamId = Guid.NewGuid();
+
+        // Grant TeamEditor permission to the random team ID so the top-level authorization policy filter passes,
+        // allowing execution to safely reach the controller's internal domain multi-tenancy boundary checks.
+        await GrantAccessPolicyAsync(BaseApiTest.TestUserId, targetType: 2, targetId: completelyRandomTeamId, role: 1);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{context.MatchId}/teams/{completelyRandomTeamId}/presence/calculate");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MatchesController.GetPlayersTimeInMatchByTeam"/> returns 400 Bad Request
+    /// when the input route parameters fail the FluentValidation empty GUID checks.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersTimeInMatchByTeam_ShouldReturnBadRequest_WhenParametersAreEmptyGuids()
+    {
+        // Arrange
+        var validTeamId = Guid.NewGuid();
+
+        // Grant Global Editor permission (targettype 0 = Global, targetId = null, role = 1 = Editor)
+        // to bypass the top-level route authorization policy and ensure execution enters the action method's validator execution block.
+        await GrantAccessPolicyAsync(BaseApiTest.TestUserId, targetType: 0, targetId: null, role: 1);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{Guid.Empty}/teams/{validTeamId}/presence/calculate");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Verifies that the administrative endpoint <see cref="MatchesController.GetPlayersTimeInMatch"/> returns 200 OK
+    /// when invoked by a user who successfully passes the tournament ownership validation block.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersTimeInMatch_Admin_ShouldReturnOk_WhenUserIsTournamentOwner()
+    {
+        // Arrange
+        // Current logged-in user in BaseApiTest context is defined as BaseApiTest.TestUserId ("auth0|test-user")
+        var context = await SeedAnalyticsEnvironmentAsync(ownerId: BaseApiTest.TestUserId);
+
+        // Act
+        var response = await Client.GetAsync($"{BaseUrl}/{context.MatchId}/teams/{context.TeamId}/presence/calculate-admin");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var analytics = await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>();
+        analytics.Should().NotBeNull();
+    }
+
+    #region Seed Helpers for Analytics
+
+    /// <summary>
+    /// Seeds a complete relational aggregate structure (Country, City, Tournament, Club, Team, Match) 
+    /// inside the containerized PostgreSQL instance to isolate integration test contexts.
+    /// </summary>
+    /// <param name="ownerId">The Auth0 user identifier assigned as the owner of the tournament.</param>
+    /// <returns>A tuple containing the generated MatchId and TeamId.</returns>
+    private async Task<(Guid MatchId, Guid TeamId)> SeedAnalyticsEnvironmentAsync(string ownerId)
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+
+        // 1. Geography
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.countries (name, code) 
+            VALUES ('Integration Country', 'INC') 
+            ON CONFLICT (name) DO NOTHING");
+        var countryId = await conn.QuerySingleAsync<int>("SELECT id FROM public.countries WHERE code = 'INC'");
+
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.regions (countryid, name) 
+            VALUES (@cid, 'Integration Region') 
+            ON CONFLICT (countryid, name) DO NOTHING",
+            new { cid = countryId });
+        var regionId = await conn.QuerySingleAsync<int>("SELECT id FROM public.regions WHERE name = 'Integration Region' AND countryid = @cid", new { cid = countryId });
+
+        var cityId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.cities (id, regionid, name) 
+            VALUES (@id, @rid, 'Integration City') 
+            ON CONFLICT (regionid, name) DO NOTHING",
+            new { id = cityId, rid = regionId });
+        cityId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.cities WHERE regionid = @rid AND name = 'Integration City'", new { rid = regionId });
+
+        // 2. User & Sport
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.users (id, email, displayname, createdat) 
+            VALUES (@id, @email, 'Tester', NOW()) 
+            ON CONFLICT (id) DO NOTHING",
+            new { id = ownerId, email = $"{ownerId}@tta.com" });
+
+        var sportId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.sports (id, name) 
+            VALUES (@id, 'Integration Sport') 
+            ON CONFLICT (name) DO NOTHING",
+            new { id = sportId });
+        sportId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.sports WHERE name = 'Integration Sport'");
+
+        var configId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.sportconfigurations (id, sportid, usescleantime, periodscount, perioddurationminutes, fieldsize, rosterlimit, lineuplimit) 
+            SELECT @id, @sid, true, 4, 8, '30x20', 15, 7 
+            WHERE NOT EXISTS (SELECT 1 FROM public.sportconfigurations WHERE sportid = @sid)",
+            new { id = configId, sid = sportId });
+        configId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.sportconfigurations WHERE sportid = @sid LIMIT 1", new { sid = sportId });
+
+        // 3. Organization (Club, Tournament, Team)
+        var clubId = Guid.NewGuid();
+        await conn.ExecuteAsync("INSERT INTO public.clubs (id, cityid, name, createdat) VALUES (@id, @cityid, @name, NOW())",
+            new { id = clubId, cityid = cityId, name = $"Club_{Guid.NewGuid():N}" });
+
+        var tournamentId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.tournaments (id, sportid, configurationid, cityid, ownerid, name, startdate, createdat) 
+            VALUES (@id, @sid, @cfgid, @cityid, @oid, @name, NOW(), NOW())",
+            new { id = tournamentId, sid = sportId, cfgid = configId, cityid = cityId, oid = ownerId, name = $"Tournament_{Guid.NewGuid():N}" });
+
+        var teamId = Guid.NewGuid();
+        await conn.ExecuteAsync("INSERT INTO public.teams (id, clubid, sportid, name, gender, createdat) VALUES (@id, @cid, @sid, @name, 0, NOW())",
+            new { id = teamId, cid = clubId, sid = sportId, name = $"Team_{Guid.NewGuid():N}" });
+
+        var matchId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.matches (id, tournamentid, hometeamid, guestteamid, scheduledat, createdat) 
+            VALUES (@id, @tid, @teamid, @teamid, NOW(), NOW())",
+            new { id = matchId, tid = tournamentId, teamid = teamId });
+
+        return (matchId, teamId);
+    }
+
+    /// <summary>
+    /// Grants a specific authorization permission policy to a user inside the test database context.
+    /// Safely ensures the referenced user exists inside public.users to satisfy database foreign key requirements.
+    /// </summary>
+    private async Task GrantAccessPolicyAsync(string userId, int targetType, Guid? targetId, int role)
+    {
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+
+        // Ensure the targeted user profile exists prior to injecting authorization rows
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.users (id, email, displayname, createdat)
+            VALUES (@id, @email, 'Integration Policy User', NOW())
+            ON CONFLICT (id) DO NOTHING",
+            new { id = userId, email = $"{userId.Replace("|", "_")}@tta.com" });
+
+        // Insert the access policy rule cleanly
+        await conn.ExecuteAsync(@"
+            INSERT INTO auth.accesspolicies (id, userid, targettype, targetid, role, createdat)
+            VALUES (@id, @userid, @targettype, @targetid, @role, NOW())
+            ON CONFLICT DO NOTHING",
+            new { id = Guid.NewGuid(), userid = userId, targettype = targetType, targetid = targetId, role = role });
+    }
+
+    #endregion
+
     #endregion
 
     #region Batch Event Time Normalization API Tests

--- a/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
+++ b/TTA.Tests.Integration/Controllers/MatchesControllerTests.cs
@@ -881,7 +881,7 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
 
     /// <summary>
     /// Verifies that <see cref="MatchesController.GetPlayersTimeInMatchByTeam"/> returns 200 OK 
-    /// with a valid collection of player time responses when the request satisfies all tenancy, validation, and TeamEditor policy rules.
+    /// with an accurately calculated collection of clean and dirty play time metrics when the pipeline executes end-to-end.
     /// </summary>
     [Fact]
     public async Task GetPlayersTimeInMatchByTeam_ShouldReturnOk_WhenRequestIsValidAndTeamBelongsToMatch()
@@ -898,8 +898,17 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var analytics = await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>();
-        analytics.Should().NotBeNull();
+        var analytics = (await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>())?.ToList();
+        analytics.Should().NotBeNull().And.NotBeEmpty();
+        analytics.Should().HaveCount(1);
+
+        // Assert end-to-end piecewise-linear mathematical calculation accuracy:
+        // Nominal duration: 8 mins, Real duration: 10 mins -> K = 0.8
+        // Dirty time: 300 seconds -> Clean time: 300 * 0.8 = 240 seconds
+        var playerRecord = analytics!.First();
+        playerRecord.MatchLineupId.Should().Be(context.LineupId);
+        playerRecord.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(300));
+        playerRecord.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(240));
     }
 
     /// <summary>
@@ -947,7 +956,7 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
 
     /// <summary>
     /// Verifies that the administrative endpoint <see cref="MatchesController.GetPlayersTimeInMatch"/> returns 200 OK
-    /// when invoked by a user who successfully passes the tournament ownership validation block.
+    /// and accurately processes the full analytic calculations when invoked by an authorized tournament owner.
     /// </summary>
     [Fact]
     public async Task GetPlayersTimeInMatch_Admin_ShouldReturnOk_WhenUserIsTournamentOwner()
@@ -962,19 +971,26 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var analytics = await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>();
-        analytics.Should().NotBeNull();
+        var analytics = (await response.Content.ReadFromJsonAsync<IEnumerable<PlayerTimeInMatchResponse>>())?.ToList();
+        analytics.Should().NotBeNull().And.NotBeEmpty();
+        analytics.Should().HaveCount(1);
+
+        // Assert end-to-end piecewise-linear mathematical calculation accuracy for admin flow
+        var playerRecord = analytics!.First();
+        playerRecord.MatchLineupId.Should().Be(context.LineupId);
+        playerRecord.DirtyTimeInMatch.Should().Be(TimeSpan.FromSeconds(300));
+        playerRecord.CleanTimeInMatch.Should().Be(TimeSpan.FromSeconds(240));
     }
 
     #region Seed Helpers for Analytics
 
     /// <summary>
-    /// Seeds a complete relational aggregate structure (Country, City, Tournament, Club, Team, Match) 
-    /// inside the containerized PostgreSQL instance to isolate integration test contexts.
+    /// Seeds a complete relational aggregate structure (Geography, Sport, Club, Tournament, Team, Match, Lineups, Time Anchors, Presences) 
+    /// inside the containerized PostgreSQL instance to isolate integration test contexts and enforce complete performance calculations.
     /// </summary>
     /// <param name="ownerId">The Auth0 user identifier assigned as the owner of the tournament.</param>
-    /// <returns>A tuple containing the generated MatchId and TeamId.</returns>
-    private async Task<(Guid MatchId, Guid TeamId)> SeedAnalyticsEnvironmentAsync(string ownerId)
+    /// <returns>A tuple containing the generated MatchId, TeamId, and target active MatchLineupId.</returns>
+    private async Task<(Guid MatchId, Guid TeamId, Guid LineupId)> SeedAnalyticsEnvironmentAsync(string ownerId)
     {
         using var conn = Fixture.ConnectionFactory.CreateConnection();
 
@@ -1000,7 +1016,7 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
             new { id = cityId, rid = regionId });
         cityId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.cities WHERE regionid = @rid AND name = 'Integration City'", new { rid = regionId });
 
-        // 2. User & Sport
+        // 2. User & Sport Configuration (8 minutes nominal duration defined)
         await conn.ExecuteAsync(@"
             INSERT INTO public.users (id, email, displayname, createdat) 
             VALUES (@id, @email, 'Tester', NOW()) 
@@ -1023,7 +1039,15 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
             new { id = configId, sid = sportId });
         configId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.sportconfigurations WHERE sportid = @sid LIMIT 1", new { sid = sportId });
 
-        // 3. Organization (Club, Tournament, Team)
+        var posId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.playerpositiondefinitions (id, sportid, name, shortname) 
+            SELECT @id, @sid, 'Center Forward', 'CF' 
+            WHERE NOT EXISTS (SELECT 1 FROM public.playerpositiondefinitions WHERE sportid = @sid AND shortname = 'CF')",
+            new { id = posId, sid = sportId });
+        posId = await conn.QuerySingleAsync<Guid>("SELECT id FROM public.playerpositiondefinitions WHERE sportid = @sid AND shortname = 'CF' LIMIT 1", new { sid = sportId });
+
+        // 3. Organization (Club, Tournament, Team, Match setup)
         var clubId = Guid.NewGuid();
         await conn.ExecuteAsync("INSERT INTO public.clubs (id, cityid, name, createdat) VALUES (@id, @cityid, @name, NOW())",
             new { id = clubId, cityid = cityId, name = $"Club_{Guid.NewGuid():N}" });
@@ -1044,7 +1068,46 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
             VALUES (@id, @tid, @teamid, @teamid, NOW(), NOW())",
             new { id = matchId, tid = tournamentId, teamid = teamId });
 
-        return (matchId, teamId);
+        // 4. Performance Analytics Computational Mock Data (Player, Roster, Lineup)
+        var playerId = Guid.NewGuid();
+        await conn.ExecuteAsync("INSERT INTO public.players (id, homeclubid, firstname, lastname, birthdate, gender, createdat) VALUES (@id, @cid, 'Analytics', 'Player', '2000-01-01', 0, NOW())", new { id = playerId, cid = clubId });
+
+        var rosterId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"INSERT INTO public.playerrosters (id, playerid, tournamentid, teamid, number, positionid, createdat) VALUES (@id, @pid, @tid, @teamid, 7, @posid, NOW())", new { id = rosterId, pid = playerId, tid = tournamentId, teamid = teamId, posid = posId });
+
+        var lineupId = Guid.NewGuid();
+        await conn.ExecuteAsync(@"INSERT INTO public.matchlineups (id, matchid, playerrosterid, number, isinstartinglineup, positionid) VALUES (@id, @mid, @rid, 7, true, @posid)", new { id = lineupId, mid = matchId, rid = rosterId, posid = posId });
+
+        // 5. Setup Time Anchors for Period 1: PeriodStart (0) and PeriodEnd (1)
+        // Real duration: 10 minutes (600 seconds) -> Scaling coefficient K = 8 / 10 = 0.8
+        var baseTime = DateTime.UtcNow;
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.timeanchors (id, matchid, periodnumber, type, timestamp)
+            VALUES 
+            (@id1, @mid, 1, 0, @timeStart),
+            (@id2, @mid, 1, 1, @timeEnd)",
+            new
+            {
+                id1 = Guid.NewGuid(),
+                id2 = Guid.NewGuid(),
+                mid = matchId,
+                timeStart = baseTime,
+                timeEnd = baseTime.AddSeconds(600)
+            });
+
+        // 6. Setup active Player Presence entry representing exactly 300 linear ("dirty") seconds in the water
+        await conn.ExecuteAsync(@"
+            INSERT INTO public.playerpresences (id, matchlineupid, periodnumber, timein, timeout)
+            VALUES (@id, @lineupId, 1, @timeIn, @timeOut)",
+            new
+            {
+                id = Guid.NewGuid(),
+                lineupId = lineupId,
+                timeIn = baseTime.AddSeconds(60),
+                timeOut = baseTime.AddSeconds(360)
+            });
+
+        return (matchId, teamId, lineupId);
     }
 
     /// <summary>
@@ -1055,14 +1118,12 @@ public class MatchesControllerTests(DatabaseFixture fixture, ITestOutputHelper o
     {
         using var conn = Fixture.ConnectionFactory.CreateConnection();
 
-        // Ensure the targeted user profile exists prior to injecting authorization rows
         await conn.ExecuteAsync(@"
             INSERT INTO public.users (id, email, displayname, createdat)
             VALUES (@id, @email, 'Integration Policy User', NOW())
             ON CONFLICT (id) DO NOTHING",
             new { id = userId, email = $"{userId.Replace("|", "_")}@tta.com" });
 
-        // Insert the access policy rule cleanly
         await conn.ExecuteAsync(@"
             INSERT INTO auth.accesspolicies (id, userid, targettype, targetid, role, createdat)
             VALUES (@id, @userid, @targettype, @targetid, @role, NOW())

--- a/TTA.Tests.Integration/Repository/PlayerPresenceRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/PlayerPresenceRepositoryTests.cs
@@ -312,6 +312,100 @@ public class PlayerPresenceRepositoryTests : BaseIntegrationTest
         newlyClosedSessions.Should().OnlyContain(p => p.TimeOut.HasValue && p.TimeOut.Value.ToString("yyyy-MM-dd HH:mm:ss") == exactTimeOut.ToString("yyyy-MM-dd HH:mm:ss"));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="PlayerPresenceRepository.GetPlayersDirtyTimeByPeriodAsync"/> returns an empty collection
+    /// when no player presence tracking records exist for the given match and team context.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersDirtyTimeByPeriodAsync_ShouldReturnEmpty_WhenNoPresenceRecordsExist()
+    {
+        // Arrange
+        var context = await SeedPresenceEnvironmentAsync();
+
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var teamId = await conn.QuerySingleAsync<Guid>(
+            "SELECT hometeamid FROM public.matches WHERE id = @MatchId",
+            new { context.MatchId });
+
+        // Act
+        var result = await _repository.GetPlayersDirtyTimeByPeriodAsync(context.MatchId, teamId);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="PlayerPresenceRepository.GetPlayersDirtyTimeByPeriodAsync"/> correctly calculates
+    /// and groups the total linear elapsed seconds spent in the water per player lineup row and match period scope.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersDirtyTimeByPeriodAsync_ShouldCalculateCorrectDirtySeconds_WhenPresenceRecordsExist()
+    {
+        // Arrange
+        var context = await SeedPresenceEnvironmentAsync();
+
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var teamId = await conn.QuerySingleAsync<Guid>(
+            "SELECT hometeamid FROM public.matches WHERE id = @MatchId",
+            new { context.MatchId });
+
+        var baseTime = DateTime.UtcNow;
+
+        // Player 1 plays 300 seconds in Period 1
+        var presence1 = new PlayerPresence
+        {
+            Id = Guid.NewGuid(),
+            MatchLineupId = context.LineupId1,
+            PeriodNumber = 1,
+            TimeIn = baseTime,
+            TimeOut = baseTime.AddSeconds(300)
+        };
+        await _repository.RecordPresenceAsync(presence1);
+
+        // Player 1 plays another 150 seconds in Period 2
+        var presence2 = new PlayerPresence
+        {
+            Id = Guid.NewGuid(),
+            MatchLineupId = context.LineupId1,
+            PeriodNumber = 2,
+            TimeIn = baseTime.AddHours(1),
+            TimeOut = baseTime.AddHours(1).AddSeconds(150)
+        };
+        await _repository.RecordPresenceAsync(presence2);
+
+        // Player 2 plays 450 seconds in Period 1
+        var presence3 = new PlayerPresence
+        {
+            Id = Guid.NewGuid(),
+            MatchLineupId = context.LineupId2,
+            PeriodNumber = 1,
+            TimeIn = baseTime,
+            TimeOut = baseTime.AddSeconds(450)
+        };
+        await _repository.RecordPresenceAsync(presence3);
+
+        // Act
+        var result = (await _repository.GetPlayersDirtyTimeByPeriodAsync(context.MatchId, teamId)).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+
+        // Verify Player 1 - Period 1 tracking metrics (300.0 seconds expected)
+        var record1 = result.FirstOrDefault(r => r.MatchLineupId == context.LineupId1 && r.PeriodNumber == 1);
+        record1.Should().NotBeNull();
+        record1!.DirtySeconds.Should().Be(300.0);
+
+        // Verify Player 1 - Period 2 tracking metrics (150.0 seconds expected)
+        var record2 = result.FirstOrDefault(r => r.MatchLineupId == context.LineupId1 && r.PeriodNumber == 2);
+        record2.Should().NotBeNull();
+        record2!.DirtySeconds.Should().Be(150.0);
+
+        // Verify Player 2 - Period 1 tracking metrics (450.0 seconds expected)
+        var record3 = result.FirstOrDefault(r => r.MatchLineupId == context.LineupId2 && r.PeriodNumber == 1);
+        record3.Should().NotBeNull();
+        record3!.DirtySeconds.Should().Be(450.0);
+    }
+
     #endregion
 
     #region Seed Helpers

--- a/TTA.Tests.Integration/Repository/PlayerPresenceRepositoryTests.cs
+++ b/TTA.Tests.Integration/Repository/PlayerPresenceRepositoryTests.cs
@@ -406,6 +406,48 @@ public class PlayerPresenceRepositoryTests : BaseIntegrationTest
         record3!.DirtySeconds.Should().Be(450.0);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="PlayerPresenceRepository.GetPlayersDirtyTimeByPeriodAsync"/> handles active presence tracking
+    /// records (where TimeOut is NULL) gracefully by returning 0.0 seconds, leveraging the database COALESCE protection loop.
+    /// </summary>
+    [Fact]
+    public async Task GetPlayersDirtyTimeByPeriodAsync_ShouldReturnZeroDirtySeconds_WhenPresenceRecordIsOpen()
+    {
+        // Arrange
+        var context = await SeedPresenceEnvironmentAsync();
+
+        using var conn = Fixture.ConnectionFactory.CreateConnection();
+        var teamId = await conn.QuerySingleAsync<Guid>(
+            "SELECT hometeamid FROM public.matches WHERE id = @MatchId",
+            new { context.MatchId });
+
+        var baseTime = DateTime.UtcNow;
+
+        // Record an active player presence with an unset TimeOut (NULL boundary state)
+        var activePresence = new PlayerPresence
+        {
+            Id = Guid.NewGuid(),
+            MatchLineupId = context.LineupId1,
+            PeriodNumber = 1,
+            TimeIn = baseTime,
+            TimeOut = null
+        };
+        await _repository.RecordPresenceAsync(activePresence);
+
+        // Act
+        var result = (await _repository.GetPlayersDirtyTimeByPeriodAsync(context.MatchId, teamId)).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+
+        var record = result.First();
+        record.MatchLineupId.Should().Be(context.LineupId1);
+        record.PeriodNumber.Should().Be(1);
+
+        // COALESCE statement in storage function converts SUM(NULL) directly to 0.0, avoiding Dapper mapping exceptions
+        record.DirtySeconds.Should().Be(0.0);
+    }
+
     #endregion
 
     #region Seed Helpers

--- a/TTA.WebAPI/Controllers/MatchesController.cs
+++ b/TTA.WebAPI/Controllers/MatchesController.cs
@@ -917,6 +917,103 @@ public class MatchesController(
         return Ok(response);
     }
 
+    /// <summary>
+    /// Calculates the clean and dirty play time performance analytics for players of a specific team in a match.
+    /// Accessible only by users holding the TeamEditor policy.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the targeted match.</param>
+    /// <param name="teamId">The unique identifier of the team whose player analytics are being calculated.</param>
+    /// <param name="validator">The FluentValidation instance injected from services to verify parameters.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests during processing.</param>
+    /// <returns>An <see cref="IActionResult"/> wrapping the collection of calculated player time-in-match metrics.</returns>
+    [HttpGet("{matchId:guid}/teams/{teamId:guid}/presence/calculate")]
+    [Authorize(Policy = "TeamEditor")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PlayerTimeInMatchResponse>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPlayersTimeInMatchByTeam(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid teamId,
+        [FromServices] IValidator<PlayerTimeInMatchRequest> validator,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Initiating team-level player time-in-match calculation for Match: {MatchId}, Team: {TeamId}.", matchId, teamId);
+
+        // 1. Instantiate the request record and execute FluentValidation boundary checks
+        var request = new PlayerTimeInMatchRequest(matchId, teamId);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for team-level player analytics request in Match {MatchId}.", matchId);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Dispatch query to validate tenancy and boundaries
+        var match = await _mediator.Send(new GetMatchByIdWithDetailsQuery(matchId), cancellationToken);
+        if (match == null)
+        {
+            _logger.LogWarning("Tenancy validation failed: Match {MatchId} not found.", matchId);
+            return NotFound($"Match with ID {matchId} was not found.");
+        }
+
+        // 3. Enforce boundary rules: teamId must belong to either Home or Guest team of the match context
+        if (teamId != match.HomeTeamId && teamId != match.GuestTeamId)
+        {
+            _logger.LogWarning("Access denied: Team {TeamId} does not belong to Match {MatchId} context boundaries.", teamId, matchId);
+            return Forbid();
+        }
+
+        // 4. Dispatch the core performance analytics query pipeline
+        var analyticsResult = await _mediator.Send(new GetPlayersTimeInMatchQuery(matchId, teamId), cancellationToken);
+
+        return Ok(analyticsResult);
+    }
+
+    /// <summary>
+    /// Calculates the clean and dirty play time performance analytics for tournament administrators.
+    /// Protected via centralized tournament ownership routine verification blocks.
+    /// </summary>
+    /// <param name="matchId">The unique identifier of the targeted match.</param>
+    /// <param name="teamId">The unique identifier of the team whose player analytics are being calculated.</param>
+    /// <param name="validator">The FluentValidation instance injected from services to verify parameters.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests during processing.</param>
+    /// <returns>An <see cref="IActionResult"/> wrapping the collection of calculated player time-in-match metrics.</returns>
+    [HttpGet("{matchId:guid}/teams/{teamId:guid}/presence/calculate-admin")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PlayerTimeInMatchResponse>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPlayersTimeInMatch(
+        [FromRoute] Guid matchId,
+        [FromRoute] Guid teamId,
+        [FromServices] IValidator<PlayerTimeInMatchRequest> validator,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Initiating admin-level player time-in-match calculation for Match: {MatchId}, Team: {TeamId}.", matchId, teamId);
+
+        // 1. Instantiate the request record and execute FluentValidation boundary checks
+        var request = new PlayerTimeInMatchRequest(matchId, teamId);
+        var validationResult = await validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            _logger.LogWarning("Validation failed for admin-level player analytics request in Match {MatchId}.", matchId);
+            return BadRequest(validationResult.Errors);
+        }
+
+        // 2. Execute administrative tournament ownership validation routine block (fixed signature)
+        var validationResultBlock = await ValidateTournamentOwnership(matchId);
+        if (validationResultBlock != null)
+        {
+            return validationResultBlock;
+        }
+
+        // 3. Dispatch the identical core performance analytics query pipeline
+        var analyticsResult = await _mediator.Send(new GetPlayersTimeInMatchQuery(matchId, teamId), cancellationToken);
+
+        return Ok(analyticsResult);
+    }
+
     #endregion
 
     #region Helper Methods

--- a/TTA.WebAPI/Controllers/MatchesController.cs
+++ b/TTA.WebAPI/Controllers/MatchesController.cs
@@ -949,13 +949,8 @@ public class MatchesController(
             return BadRequest(validationResult.Errors);
         }
 
-        // 2. Dispatch query to validate tenancy and boundaries
+        // 2. Dispatch query to validate tenancy and boundaries (Throws NotFoundException internally if missing)
         var match = await _mediator.Send(new GetMatchByIdWithDetailsQuery(matchId), cancellationToken);
-        if (match == null)
-        {
-            _logger.LogWarning("Tenancy validation failed: Match {MatchId} not found.", matchId);
-            return NotFound($"Match with ID {matchId} was not found.");
-        }
 
         // 3. Enforce boundary rules: teamId must belong to either Home or Guest team of the match context
         if (teamId != match.HomeTeamId && teamId != match.GuestTeamId)


### PR DESCRIPTION
# 🚀 Pull Request: Feature - Player Time-in-Match Performance Analytics #56

## 🎯 Description
This Pull Request completely implements the post-match player time-in-match performance analytics workflow detailed in **Issue #55**. It introduces a split-responsibility architecture consisting of a high-performance database extraction phase and an optimized business logic normalization phase. The pipeline calculates both raw linear ("dirty") time and scaled ("clean") time spent in the water for every active player or team placeholder across all match periods.

**Closes**: #55

---

## 🛠 Type of Change
- [x] **Feat**: New feature (non-breaking change which adds functionality)
- [x] **Test**: New Unit and Integration tests proving the architecture stability

---

## 📐 Detailed Layer Breakdown

### 1. Database & Persistence Layer
- **PL/pgSQL Routine**: Implemented the relational storage function `public.calculate_players_dirty_time_by_period(p_match_id UUID, p_team_id UUID)` inside `02-Storage-procedures.sql`. It aggregates intervals between `timein` and `timeout` from `public.playerpresences`, groups rows by `matchlineupid` and `periodnumber`, and supports team placeholders (`-1` for Home, `-2` for Guest).
- **SQL Constants Mapping**: Added `CalculatePlayersDirtyTimeByPeriod` command placholder directly inside the existing `SqlStatements.ForPlayerPresence` class with correct `p_` prefix parameter naming conventions.
- **Strongly-Typed Projections**: Created `PlayersDirtyTimeByPeriodProjection` record to avoid `dynamic` object mappings, ensuring strict compile-time safety during Dapper data collection.
- **Repository Implementation**: Extended `IPlayerPresenceRepository` and `PlayerPresenceRepository` using `EntityRepositoryBase` connection workflows to query the database cleanly.

### 2. Core Business Logic Layer (MediatR & DTO)
- **Data Transfer Objects**: Created unified `PlayerTimeInMatchRequest` and `PlayerTimeInMatchResponse` records inside features scope to guarantee clean data boundary transport.
- **FluentValidation**: Added `PlayerTimeInMatchRequestValidator` to prevent empty GUID evaluation right at the API gate, emitting explicit validation warning exceptions.
- **MediatR Pipeline**: Created `GetPlayersTimeInMatchQuery` and its corresponding handler `GetPlayersTimeInMatchQueryHandler`. The handler optimizes processing by caching distinctive period scale coefficients `K` via `ITimeNormalizationService` into a look-up `Dictionary` to fully protect the system against nested `N+1` async database execution patterns.

### 3. API Controller & Security Layer
- **MatchesController Analytical Endpoints**:
  - `GET /api/Matches/{matchId}/teams/{teamId}/presence/calculate` (`GetPlayersTimeInMatchByTeam`): Restricted via `[Authorize(Policy = "TeamEditor")]`. Implements multi-tenant checks via `GetMatchByIdWithDetailsQuery` to block cross-tenant parameter manipulation (returns `403 Forbidden` if the requested team does not belong to the match boundaries).
  - `GET /api/Matches/{matchId}/teams/{teamId}/presence/calculate-admin` (`GetPlayersTimeInMatch`): Exposed for tournament organizers, secured using the controller's internal `ValidateTournamentOwnership(matchId)` routine.
- Both endpoints are heavily decorated with `[ProducesResponseType]` codes (`200 OK`, `400 BadRequest`, `403 Forbidden`, `404 NotFound`) and invoke `[FromServices]` valdiators to intercept invalid route parameters.

### 4. Quality Assurance & Test Coverage
- **Unit Testing Layer**:
  - Implemented `PlayerTimeInMatchRequestValidatorTests` asserting route parameter constraint configurations via `TestValidate`.
  - Implemented `GetPlayersTimeInMatchQueryHandlerTests` mocking repository projection responses to check exact grouping accumulations, mathematical scaling (`DirtySeconds * K`), and caching call tracking counters.
- **Integration Testing Layer**:
  - Implemented `PlayerPresenceRepositoryTests` verifying that the PL/pgSQL relational code computes valid linear intervals on containerized PostgreSQL instances.
  - Implemented `MatchesControllerTests` asserting full routing tables, FluentValidation interception blocks, and role permissions. Configured `GrantAccessPolicyAsync` seed helpers to insert dummy users into `public.users` prior to writing policy definitions to prevent database foreign-key constraint violations during `Respawner` clearing loops.

---

## 🧪 Verification Status
- [x] All Unit tests pass locally.
- [x] All Integration tests executed inside the test container environment pass seamlessly (Green).
- [x] All variables, code comments, and XML doc strings are authored strictly in **English** using standard C# 12 primary constructor formatting rules.

## Summary for CodeRabbit

* **New Features**
  * Added team-level and admin-level analytical endpoints to calculate clean and dirty play times for players within a match context.
  * Introduced a high-performance analytical pipeline that queries period-specific play durations and aggregates normalized metrics.
* **Architecture & Database**
  * Created a PostgreSQL storage function to extract exact linear play durations grouped by periods.
  * Added a strongly-typed database projection layer replacing loose `dynamic` mapping types.
* **Tests**
  * Added unit tests for request validators and aggregation handlers checking scaling math equations.
  * Added database and controller integration tests covering security policies, multi-tenant boundaries, and data constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added player time-in-match analytics endpoints for team editors and tournament admins.
  * Responses now return per player match lineup time analytics including both “clean” and “dirty” totals.

* **Bug Fixes**
  * Requests with missing/empty match or team identifiers are rejected.
  * When no presence data exists, analytics return an empty result.
  * Improved resilience: if time normalization fails, “clean” time falls back to raw “dirty” time.

* **Tests**
  * Added unit and integration coverage for validation, access rules, repository grouping, and calculation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->